### PR TITLE
Fix date tests

### DIFF
--- a/packages/core/tests/integrations/ar.test.ts
+++ b/packages/core/tests/integrations/ar.test.ts
@@ -87,16 +87,15 @@ test("date parser error messages", () => {
   expect(getErrorMessage(schema.safeParse("2022-12-01"))).toEqual(
     "المتوقع تاريخ، المستلم سلسلة"
   );
+
+  const testDate = new Date("2022-08-01");
+
   expect(
-    getErrorMessage(
-      schema.min(new Date("2022-08-01")).safeParse(new Date("2022-07-29"))
-    )
-  ).toEqual("يجب أن يكون التاريخ أكبر من أو يساوي ١‏/٨‏/٢٠٢٢");
+    getErrorMessage(schema.min(testDate).safeParse(new Date("2022-07-29")))
+  ).toEqual("يجب أن يكون التاريخ أكبر من أو يساوي ١‏/٨‏/٢٠٢٢"); // ${testDate.toLocaleDateString("ar")}
   expect(
-    getErrorMessage(
-      schema.max(new Date("2022-08-01")).safeParse(new Date("2022-08-02"))
-    )
-  ).toEqual(`يجب أن يكون التاريخ أصغر من أو يساوي ١‏/٨‏/٢٠٢٢`);
+    getErrorMessage(schema.max(testDate).safeParse(new Date("2022-08-02")))
+  ).toEqual(`يجب أن يكون التاريخ أصغر من أو يساوي ١‏/٨‏/٢٠٢٢`); // ${testDate.toLocaleDateString("ar")}
 });
 
 test("array parser error messages", () => {

--- a/packages/core/tests/integrations/ar.test.ts
+++ b/packages/core/tests/integrations/ar.test.ts
@@ -92,10 +92,14 @@ test("date parser error messages", () => {
 
   expect(
     getErrorMessage(schema.min(testDate).safeParse(new Date("2022-07-29")))
-  ).toEqual("يجب أن يكون التاريخ أكبر من أو يساوي ١‏/٨‏/٢٠٢٢"); // ${testDate.toLocaleDateString("ar")}
+  ).toEqual(
+    `يجب أن يكون التاريخ أكبر من أو يساوي ${testDate.toLocaleDateString("ar")}`
+  );
   expect(
     getErrorMessage(schema.max(testDate).safeParse(new Date("2022-08-02")))
-  ).toEqual(`يجب أن يكون التاريخ أصغر من أو يساوي ١‏/٨‏/٢٠٢٢`); // ${testDate.toLocaleDateString("ar")}
+  ).toEqual(
+    `يجب أن يكون التاريخ أصغر من أو يساوي ${testDate.toLocaleDateString("ar")}`
+  );
 });
 
 test("array parser error messages", () => {

--- a/packages/core/tests/integrations/en.test.ts
+++ b/packages/core/tests/integrations/en.test.ts
@@ -83,16 +83,19 @@ test("date parser error messages", () => {
   expect(getErrorMessage(schema.safeParse("2022-12-01"))).toEqual(
     "Expected date, received string"
   );
+
+  const testDate = new Date("2022-08-01");
+
   expect(
-    getErrorMessage(
-      schema.min(new Date("2022-08-01")).safeParse(new Date("2022-07-29"))
-    )
-  ).toEqual(`Date must be greater than or equal to 8/1/2022`);
+    getErrorMessage(schema.min(testDate).safeParse(new Date("2022-07-29")))
+  ).toEqual(
+    `Date must be greater than or equal to ${testDate.toLocaleDateString("en")}`
+  );
   expect(
-    getErrorMessage(
-      schema.max(new Date("2022-08-01")).safeParse(new Date("2022-08-02"))
-    )
-  ).toEqual(`Date must be smaller than or equal to 8/1/2022`);
+    getErrorMessage(schema.max(testDate).safeParse(new Date("2022-08-02")))
+  ).toEqual(
+    `Date must be smaller than or equal to ${testDate.toLocaleDateString("en")}`
+  );
 });
 
 test("array parser error messages", () => {

--- a/packages/core/tests/integrations/fr.test.ts
+++ b/packages/core/tests/integrations/fr.test.ts
@@ -85,16 +85,19 @@ test("date parser error messages", () => {
   expect(getErrorMessage(schema.safeParse("2022-12-01"))).toEqual(
     "Type invalide: date doit être fourni(e), mais chaîne de caractères a été reçu(e)"
   );
+
+  const testDate = new Date("2022-08-01");
+
   expect(
-    getErrorMessage(
-      schema.min(new Date("2022-08-01")).safeParse(new Date("2022-07-29"))
-    )
-  ).toEqual(`Date doit être supérieure ou égale à 01/08/2022`);
+    getErrorMessage(schema.min(testDate).safeParse(new Date("2022-07-29")))
+  ).toEqual(
+    `Date doit être supérieure ou égale à ${testDate.toLocaleDateString("fr")}`
+  );
   expect(
-    getErrorMessage(
-      schema.max(new Date("2022-08-01")).safeParse(new Date("2022-08-02"))
-    )
-  ).toEqual(`Date doit être inférieure ou égale à 01/08/2022`);
+    getErrorMessage(schema.max(testDate).safeParse(new Date("2022-08-02")))
+  ).toEqual(
+    `Date doit être inférieure ou égale à ${testDate.toLocaleDateString("fr")}`
+  );
 });
 
 test("array parser error messages", () => {

--- a/packages/core/tests/integrations/ja.test.ts
+++ b/packages/core/tests/integrations/ja.test.ts
@@ -87,16 +87,19 @@ test("date parser error messages", () => {
   expect(getErrorMessage(schema.safeParse("2022-12-01"))).toEqual(
     "日時での入力を期待していますが、文字列が入力されました。"
   );
+
+  const testDate = new Date("2022-08-01");
+
   expect(
-    getErrorMessage(
-      schema.min(new Date("2022-08-01")).safeParse(new Date("2022-07-29"))
-    )
-  ).toEqual(`2022/8/1以降の日時である必要があります。`);
+    getErrorMessage(schema.min(testDate).safeParse(new Date("2022-07-29")))
+  ).toEqual(
+    `${testDate.toLocaleDateString("ja")}以降の日時である必要があります。`
+  );
   expect(
-    getErrorMessage(
-      schema.max(new Date("2022-08-01")).safeParse(new Date("2022-08-02"))
-    )
-  ).toEqual(`2022/8/1以前の日時である必要があります。`);
+    getErrorMessage(schema.max(testDate).safeParse(new Date("2022-08-02")))
+  ).toEqual(
+    `${testDate.toLocaleDateString("ja")}以前の日時である必要があります。`
+  );
 });
 
 test("array parser error messages", () => {

--- a/packages/core/tests/integrations/pt.test.ts
+++ b/packages/core/tests/integrations/pt.test.ts
@@ -85,16 +85,19 @@ test("date parser error messages", () => {
   expect(getErrorMessage(schema.safeParse("2022-12-01"))).toEqual(
     "O dado deve ser do tipo date, porém foi enviado string"
   );
+
+  const testDate = new Date("2022-08-01");
+
   expect(
-    getErrorMessage(
-      schema.min(new Date("2022-08-01")).safeParse(new Date("2022-07-29"))
-    )
-  ).toEqual(`Data precisa ser maior ou igual a 01/08/2022`);
+    getErrorMessage(schema.min(testDate).safeParse(new Date("2022-07-29")))
+  ).toEqual(
+    `Data precisa ser maior ou igual a ${testDate.toLocaleDateString("pt")}`
+  );
   expect(
-    getErrorMessage(
-      schema.max(new Date("2022-08-01")).safeParse(new Date("2022-08-02"))
-    )
-  ).toEqual(`A data precisa ser menor ou igual a 01/08/2022`);
+    getErrorMessage(schema.max(testDate).safeParse(new Date("2022-08-02")))
+  ).toEqual(
+    `A data precisa ser menor ou igual a ${testDate.toLocaleDateString("pt")}`
+  );
 });
 
 test("array parser error messages", () => {

--- a/packages/core/tests/integrations/zh-CN.test.ts
+++ b/packages/core/tests/integrations/zh-CN.test.ts
@@ -77,16 +77,19 @@ test("date parser error messages", () => {
   expect(getErrorMessage(schema.safeParse("2022-12-01"))).toEqual(
     "期望输入的是日期, 而输入的是字符串"
   );
+
+  const testDate = new Date("2022-08-01");
+
   expect(
     getErrorMessage(
       schema.min(new Date("2022-08-01")).safeParse(new Date("2022-07-29"))
     )
-  ).toEqual(`日期必须晚于或等于 2022/8/1`);
+  ).toEqual(`日期必须晚于或等于 ${testDate.toLocaleDateString("zh-CN")}`);
   expect(
     getErrorMessage(
       schema.max(new Date("2022-08-01")).safeParse(new Date("2022-08-02"))
     )
-  ).toEqual(`日期必须早于或等于 2022/8/1`);
+  ).toEqual(`日期必须早于或等于 ${testDate.toLocaleDateString("zh-CN")}`);
 });
 
 test("array parser error messages", () => {


### PR DESCRIPTION
The tests for the date syntax were breaking because the JS Date object is created automatically with the local machine's timezone, and depending on the machine's timezone the date's toString() method used internally by Zod (which displays UTC) could be displayed as a day prior or in advance to the actual date passed in to the constructor.

Because the tests' error messages were using the same date passed to the constructor as hard-coded strings, they were in danger of suffering the conversion mentioned previously. Now, I have changed the error messages to use the JS [Date.toLocaleDateString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString) method with the original date which is being tested by, this way we can display the date in the same timezone that Zod is testing by internally and also we can pass via parameter the locale in which we want to display, so we can pass in the locale of each test file accordingly.

Closes #11 