### PR TITLE
Fix issue #10

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,8 +28,8 @@ export const makeZodI18nMap =
           });
         } else {
           message = t("zod:errors.invalid_type", {
-            expected: `$t(zod:types.${issue.expected})`,
-            received: `$t(zod:types.${issue.received})`,
+            expected: t(`zod:types.${issue.expected})`),
+            received: t(`zod:types.${issue.received})`),
             defaultValue: message,
           });
         }
@@ -94,7 +94,7 @@ export const makeZodI18nMap =
           }
         } else {
           message = t(`zod:errors.invalid_string.${issue.validation}`, {
-            validation: `$t(zod:validations.${issue.validation})`,
+            validation: t(`zod:validations.${issue.validation})`),
             defaultValue: message,
           });
         }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,14 +1,14 @@
 import { ZodIssueCode, ZodParsedType, defaultErrorMap, ZodErrorMap } from "zod";
 import i18next, { i18n } from "i18next";
 
-const jsonStringifyReplacer = (_: string, value: any): any => {
+const jsonStringifyReplacer = <T>(_: string, value: T) => {
   if (typeof value === "bigint") {
     return value.toString();
   }
   return value;
 };
 
-function joinValues<T extends any[]>(array: T, separator = " | "): string {
+function joinValues<T extends unknown[]>(array: T, separator = " | "): string {
   return array
     .map((val) => (typeof val === "string" ? `'${val}'` : val))
     .join(separator);


### PR DESCRIPTION
# fix issue #10 
- refactor: refactor "any" into more helpful type generics
- fix: fix issue #10 where some error messages were not translated correctly due to the translation function not wrapping the template string