### PR TITLE
v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,20 +21,149 @@ import i18next from 'i18next'
 import { z } from 'zod'
 import { zodI18nMap } from 'zod-i18n-map'
 // Import your language translation files
-import translation from 'zod-i18n-map/locales/ja/zod.json'
+import translation from 'zod-i18n-map/locales/es/zod.json'
 
 // lng and resources key depend on your locale.
 i18next.init({
-  lng: 'ja',
+  lng: 'es',
   resources: {
-    ja: { zod: translation },
+    es: { zod: translation },
   },
 });
 z.setErrorMap(zodI18nMap)
 
 const schema = z.string().email()
-schema.parse('foo') // メールアドレスの形式で入力してください。
+// Translated into Spanish (es)
+schema.parse('foo') // => correo inválido
 ```
+
+## `makeZodI18nMap`
+
+Detailed customization is possible by using `makeZodI18nMap` and option values.
+
+```ts
+export type MakeZodI18nMap = (option?: ZodI18nMapOption) => ZodErrorMap;
+
+export type ZodI18nMapOption = {
+  t?: i18n["t"];
+  ns?: string | readonly string[]; // See: `Namespace`
+  handlePath?: { // See: `Handling object schema keys`
+    context?: string;
+    ns?: string | readonly string[];
+    keyPrefix?: string;
+  }; 
+};
+```
+
+### Namespace (`ns`)
+
+You can switch between translation files by specifying a namespace.  
+This is useful in cases where the application handles validation messages for different purposes, e.g., validation messages for forms are for end users, while input value checks for API schemas are for developers.
+
+The default namespace is `zod`.
+
+```ts
+import i18next from 'i18next'
+import { z } from 'zod'
+import { makeZodI18nMap } from "zod-i18n-map";
+
+i18next.init({
+  lng: 'en',
+  resources: {
+    en: { 
+      zod: { // default namespace
+        invalid_type: "Error: expected {{expected}}, received {{received}}"
+      },
+      formValidation: { // custom namespace
+        invalid_type: "it is expected to provide {{expected}} but you provided {{received}}"
+      },
+    },
+  },
+});
+
+// use default namespace
+z.setErrorMap(makeZodI18nMap())
+z.string().parse(1) // => Error: expected string, received number
+
+// select custom namespace
+z.setErrorMap(makeZodI18nMap({ ns: 'formValidation' }))
+z.string().parse(1) // => it is expected to provide string but you provided number
+```
+
+### Handling object schema keys (`handlePath`)
+
+When dealing with structured data, such as when using Zod as a validator for form input values, it is common to generate a schema with `z.object`.  
+You can handle the object's key in the message by preparing messages with the key in the `with_path` context.
+
+```ts
+import i18next from 'i18next'
+import { z } from 'zod'
+import { zodI18nMap } from "zod-i18n-map";
+
+i18next.init({
+  lng: "en",
+  resources: {
+    en: {
+      zod: {
+        errors: {
+          invalid_type: "Expected {{expected}}, received {{received}}",
+          invalid_type_with_path:
+            "{{path}} is expected {{expected}}, received {{received}}",
+        },
+        userName: "User's name",
+      },
+    },
+  },
+});
+
+z.setErrorMap(zodI18nMap);
+
+z.string().parse(1) // => Expected string, received number
+
+const schema = z.object({
+  userName: z.string(),
+});
+schema.parse({ userName: 1 }) // => User's name is expected string, received number
+```
+
+If `_with_path` is suffixed to the key of the message, that message will be adopted in the case of an object type schema.  
+If there is no message key with `_with_path`, fall back to the normal error message.  
+The suffix can be changed by specifying `handlePath.context`.
+
+Object schema keys can be handled in the message with `{{path}}`.  
+By preparing the translated data for the same key as the key in the object schema, the translated value will be output in `{{path}}`, otherwise the key will be output as is.
+You can also separate namespaces for translation data for `{{path}}` by specifying `handlePath.ns`. Furthermore, it is possible to access nested translation data by specifying `handlePath.keyPrefix`.
+
+```ts
+i18next.init({
+  lng: "en",
+  resources: {
+    en: {
+      zod: {
+        errors: {
+          invalid_type: "Expected {{expected}}, received {{received}}",
+          invalid_type_with_path:
+            "{{- path}} is expected {{expected}}, received {{received}}",
+        },
+      },
+      form: {
+        group: {
+          userName: "User's name",
+        }
+      }
+    },
+  },
+});
+
+z.setErrorMap(zodI18nMap({ 
+  handlePath: {
+    ns: "form",
+    keyPrefix: "group"
+  }
+}));
+```
+
+
 
 ## Translation Files
 `zod-i18n-map` contains translation files for several locales.

--- a/examples/with-next-i18next/README.md
+++ b/examples/with-next-i18next/README.md
@@ -62,7 +62,7 @@ module.exports = {
 By giving the `t` method from `useTranslation` as an argument to `makeZodI18nMap` and giving it as an argument to `z.setErrorMap`, the zod error messages are automatically translated.
 ```ts
 const { t } = useTranslation();
-z.setErrorMap(makeZodI18nMap(t));
+z.setErrorMap(makeZodI18nMap({ t }));
 ```
 
 Finally, the page file will be as follows.
@@ -89,7 +89,7 @@ const schema = z.object({
 
 export default function Page() {
   const { t } = useTranslation();
-  z.setErrorMap(makeZodI18nMap(t));
+  z.setErrorMap(makeZodI18nMap({ t }));
   const {
     register,
     handleSubmit,

--- a/examples/with-next-i18next/pages/index.tsx
+++ b/examples/with-next-i18next/pages/index.tsx
@@ -39,7 +39,7 @@ const schema = z.object({
 
 export default function HookForm() {
   const { t } = useTranslation();
-  z.setErrorMap(makeZodI18nMap({ t }));
+  z.setErrorMap(makeZodI18nMap({ t, handlePath: { ns: ["common", "zod"] } }));
   const router = useRouter();
 
   const {
@@ -90,11 +90,11 @@ export default function HookForm() {
       <form onSubmit={handleSubmit(console.log)}>
         <FormControl isInvalid={!!errors.username} mb={4}>
           <FormLabel htmlFor="username">
-            <Trans>User name</Trans>
+            <Trans>username</Trans>
           </FormLabel>
           <Input
             id="username"
-            placeholder={t("John Doe") ?? undefined}
+            placeholder={t("username_placeholder") ?? undefined}
             {...register("username")}
           />
           <FormErrorMessage>
@@ -103,7 +103,7 @@ export default function HookForm() {
         </FormControl>
         <FormControl isInvalid={!!errors.email} mb={4}>
           <FormLabel htmlFor="email">
-            <Trans>Email</Trans>
+            <Trans>email</Trans>
           </FormLabel>
           <Input
             id="email"
@@ -116,7 +116,7 @@ export default function HookForm() {
         </FormControl>
         <FormControl isInvalid={!!errors.favoriteNumber} mb={4}>
           <FormLabel htmlFor="favoriteNumber">
-            <Trans>Favorite number</Trans>
+            <Trans>favoriteNumber</Trans>
           </FormLabel>
           <Input
             id="favoriteNumber"
@@ -132,7 +132,7 @@ export default function HookForm() {
           isLoading={isSubmitting}
           type="submit"
         >
-          <Trans>Submit</Trans>
+          <Trans>submit</Trans>
         </Button>
       </form>
     </Container>

--- a/examples/with-next-i18next/pages/index.tsx
+++ b/examples/with-next-i18next/pages/index.tsx
@@ -39,7 +39,7 @@ const schema = z.object({
 
 export default function HookForm() {
   const { t } = useTranslation();
-  z.setErrorMap(makeZodI18nMap(t));
+  z.setErrorMap(makeZodI18nMap({ t }));
   const router = useRouter();
 
   const {

--- a/examples/with-next-i18next/public/locales/ar/common.json
+++ b/examples/with-next-i18next/public/locales/ar/common.json
@@ -1,7 +1,7 @@
 {
-  "User name": "اسم المستخدم",
-  "John Doe": "محمد ماهر",
-  "Email": "البريد الالكتروني",
-  "Favorite number": "الرقم المفضل",
-  "Submit": "ارسال"
+  "username": "اسم المستخدم",
+  "username_placeholder": "محمد ماهر",
+  "email": "البريد الالكتروني",
+  "favoriteNumber": "الرقم المفضل",
+  "submit": "ارسال"
 }

--- a/examples/with-next-i18next/public/locales/en/common.json
+++ b/examples/with-next-i18next/public/locales/en/common.json
@@ -1,1 +1,7 @@
-{}
+{
+  "username": "User name",
+  "username_placeholder": "John Doe",
+  "email": "Email",
+  "favoriteNumber": "Favorite number",
+  "submit": "Submit"
+}

--- a/examples/with-next-i18next/public/locales/en/zod.json
+++ b/examples/with-next-i18next/public/locales/en/zod.json
@@ -1,6 +1,7 @@
 {
   "errors": {
     "invalid_type": "Expected {{expected}}, received {{received}}",
+    "invalid_type_with_path": "{{path}} is expected {{expected}}, but received {{received}}",
     "invalid_type_received_undefined": "Required",
     "invalid_literal": "Invalid literal value, expected {{expected}}",
     "unrecognized_keys": "Unrecognized key(s) in object: {{- keys}}",
@@ -31,11 +32,15 @@
       },
       "string": {
         "inclusive": "String must contain at least {{minimum}} character(s)",
-        "not_inclusive": "String must contain over {{minimum}} character(s)"
+        "inclusive_with_path": "{{path}} must contain at least {{minimum}} character(s)",
+        "not_inclusive": "String must contain over {{minimum}} character(s)",
+        "not_inclusive_with_path": "{{path}} must contain over {{minimum}} character(s)"
       },
       "number": {
         "inclusive": "Number must be greater than or equal to {{minimum}}",
-        "not_inclusive": "Number must be greater than {{minimum}}"
+        "inclusive_with_path": "{{path}} must be greater than or equal to {{minimum}}",
+        "not_inclusive": "Number must be greater than {{minimum}}",
+        "not_inclusive_with_path": "{{path}} must be greater than {{minimum}}"
       },
       "set": {
         "inclusive": "Invalid input",
@@ -53,11 +58,15 @@
       },
       "string": {
         "inclusive": "String must contain at most {{maximum}} character(s)",
-        "not_inclusive": "String must contain under {{maximum}} character(s)"
+        "inclusive_with_path": "{{path}} must contain at most {{maximum}} character(s)",
+        "not_inclusive": "String must contain under {{maximum}} character(s)",
+        "not_inclusive_with_path": "{{path}} must contain under {{maximum}} character(s)"
       },
       "number": {
         "inclusive": "Number must be less than or equal to {{maximum}}",
-        "not_inclusive": "Number must be less than {{maximum}}"
+        "inclusive_with_path": "{{path}} must be less than or equal to {{maximum}}",
+        "not_inclusive": "Number must be less than {{maximum}}",
+        "not_inclusive_with_path": "{{path}} must be less than {{maximum}}"
       },
       "set": {
         "inclusive": "Invalid input",

--- a/examples/with-next-i18next/public/locales/es/common.json
+++ b/examples/with-next-i18next/public/locales/es/common.json
@@ -1,7 +1,7 @@
 {
-  "User name": "Nombre de usuario",
-  "John Doe": "John Doe",
-  "Email": "Correo",
-  "Favorite number": "Número favorito",
-  "Submit": "Enviar"
+  "username": "Nombre de usuario",
+  "username_placeholder": "John Doe",
+  "email": "Correo",
+  "favoriteNumber": "Número favorito",
+  "submit": "Enviar"
 }

--- a/examples/with-next-i18next/public/locales/fr/common.json
+++ b/examples/with-next-i18next/public/locales/fr/common.json
@@ -1,7 +1,7 @@
 {
-  "User name": "Nom d'utilisateur",
-  "John Doe": "John Doe",
-  "Email": "E-mail",
-  "Favorite number": "Nombre favori",
-  "Submit": "Soumettre"
+  "username": "Nom d'utilisateur",
+  "username_placeholder": "John Doe",
+  "email": "E-mail",
+  "favoriteNumber": "Nombre favori",
+  "submit": "Soumettre"
 }

--- a/examples/with-next-i18next/public/locales/is/common.json
+++ b/examples/with-next-i18next/public/locales/is/common.json
@@ -1,7 +1,7 @@
 {
-  "User name": "Notendanafn",
-  "John Doe": "Jón Jónsson",
-  "Email": "Netfang",
-  "Favorite number": "Uppáhalds tala",
-  "Submit": "Senda"
+  "username": "Notendanafn",
+  "username_placeholder": "Jón Jónsson",
+  "email": "Netfang",
+  "favoriteNumber": "Uppáhalds tala",
+  "submit": "Senda"
 }

--- a/examples/with-next-i18next/public/locales/ja/common.json
+++ b/examples/with-next-i18next/public/locales/ja/common.json
@@ -1,7 +1,7 @@
 {
-  "User name": "ユーザー名",
-  "John Doe": "山田太郎",
-  "Email": "メールアドレス",
-  "Favorite number": "好きな数字",
-  "Submit": "送信"
+  "username": "ユーザー名",
+  "username_placeholder": "山田太郎",
+  "email": "メールアドレス",
+  "favoriteNumber": "好きな数字",
+  "submit": "送信"
 }

--- a/examples/with-next-i18next/public/locales/ja/zod.json
+++ b/examples/with-next-i18next/public/locales/ja/zod.json
@@ -2,6 +2,7 @@
   "errors": {
     "invalid_type":
     "{{expected}}での入力を期待していますが、{{received}}が入力されました。",
+    "invalid_type_with_path": "{{path}}は{{expected}}で入力してください。",
     "invalid_type_received_undefined": "必須",
     "invalid_literal": "無効なリテラル値です。{{expected}}を入力してください。",
     "unrecognized_keys": "オブジェクトのキー{{- keys}}が識別できません。",
@@ -34,11 +35,15 @@
       },
       "string": {
         "inclusive": "{{minimum}}文字以上の文字列である必要があります。",
-        "not_inclusive": "{{minimum}}文字より長い文字列である必要があります。"
+        "inclusive_with_path": "{{path}}は{{minimum}}文字以上の文字列である必要があります。",
+        "not_inclusive": "{{minimum}}文字より長い文字列である必要があります。",
+        "not_inclusive_with_path": "{{path}}は{{minimum}}文字より長い文字列である必要があります。"
       },
       "number": {
         "inclusive": "{{minimum}}以上の数値である必要があります。",
-        "not_inclusive": "{{minimum}}より大きな数値である必要があります。"
+        "inclusive_with_path": "{{path}}は{{minimum}}以上の数値である必要があります。",
+        "not_inclusive": "{{minimum}}より大きな数値である必要があります。",
+        "not_inclusive_with_path": "{{path}}は{{minimum}}より大きな数値である必要があります。"
       },
       "set": {
         "inclusive": "入力形式が間違っています。",
@@ -57,11 +62,15 @@
       },
       "string": {
         "inclusive": "{{maximum}}文字以下の文字列である必要があります。",
-        "not_inclusive": "{{maximum}}文字より短い文字列である必要があります。"
+        "inclusive_with_path": "{{path}}は{{maximum}}文字以下の文字列である必要があります。",
+        "not_inclusive": "{{maximum}}文字より短い文字列である必要があります。",
+        "not_inclusive_with_path": "{{path}}は{{maximum}}文字より短い文字列である必要があります。"
       },
       "number": {
         "inclusive": "{{maximum}}以下の数値である必要があります。",
-        "not_inclusive": "{{maximum}}より小さな数値である必要があります。"
+        "inclusive_with_path": "{{path}}は{{maximum}}以下の数値である必要があります。",
+        "not_inclusive": "{{maximum}}より小さな数値である必要があります。",
+        "not_inclusive_with_path": "{{path}}は{{maximum}}より小さな数値である必要があります。"
       },
       "set": {
         "inclusive": "入力形式が間違っています。",

--- a/examples/with-next-i18next/public/locales/pt/common.json
+++ b/examples/with-next-i18next/public/locales/pt/common.json
@@ -1,7 +1,7 @@
 {
-  "User name": "Nome do usuário",
-  "John Doe": "João Maria",
-  "Email": "E-mail",
-  "Favorite number": "Número favorito",
-  "Submit": "Enviar"
+  "username": "Nome do usuário",
+  "username_placeholder": "João Maria",
+  "email": "E-mail",
+  "favoriteNumber": "Número favorito",
+  "submit": "Enviar"
 }

--- a/examples/with-next-i18next/public/locales/zh-CN/common.json
+++ b/examples/with-next-i18next/public/locales/zh-CN/common.json
@@ -1,8 +1,8 @@
 {
-  "User name": "用户名",
-  "John Doe": "李华",
-  "Email": "邮箱",
-  "Favorite number": "喜欢的数字",
-  "Submit": "提交"
+  "username": "用户名",
+  "username_placeholder": "李华",
+  "email": "邮箱",
+  "favoriteNumber": "喜欢的数字",
+  "submit": "提交"
 }
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -71,10 +71,10 @@ i18next.init({
   lng: 'en',
   resources: {
     en: { 
-      zod: {
+      zod: { // default namespace
         invalid_type: "Error: expected {{expected}}, received {{received}}"
       },
-      formValidation: {
+      formValidation: { // custom namespace
         invalid_type: "it is expected to provide {{expected}} but you provided {{received}}"
       },
     },
@@ -85,7 +85,7 @@ i18next.init({
 z.setErrorMap(makeZodI18nMap())
 z.string().parse(1) // => Error: expected string, received number
 
-// select formValidation namespace
+// select custom namespace
 z.setErrorMap(makeZodI18nMap({ ns: 'formValidation' }))
 z.string().parse(1) // => it is expected to provide string but you provided number
 ```
@@ -110,7 +110,7 @@ i18next.init({
           invalid_type_with_path:
             "{{path}} is expected {{expected}}, received {{received}}",
         },
-        userName: "user's name",
+        userName: "User's name",
       },
     },
   },
@@ -123,14 +123,14 @@ z.string().parse(1) // => Expected string, received number
 const schema = z.object({
   userName: z.string(),
 });
-schema.parse({ userName: 1 }) // => user's name is expected string, received number
+schema.parse({ userName: 1 }) // => User's name is expected string, received number
 ```
 
 If `_with_path` is suffixed to the key of the message, that message will be adopted in the case of an object type schema.  
 If there is no message key with `_with_path`, fall back to the normal error message.  
 The suffix can be changed by specifying `handlePath.context`.
 
-Path information can be handled in the message with `{{path}}`.  
+Object schema keys can be handled in the message with `{{path}}`.  
 By preparing the translated data for the same key as the key in the object schema, the translated value will be output in `{{path}}`, otherwise the key will be output as is.
 You can also separate namespaces for translation data for `{{path}}` by specifying `handlePath.ns`. Furthermore, it is possible to access nested translation data by specifying `handlePath.keyPrefix`.
 
@@ -148,7 +148,7 @@ i18next.init({
       },
       form: {
         group: {
-          userName: "user's name",
+          userName: "User's name",
         }
       }
     },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,7 @@ function joinValues<T extends any[]>(array: T, separator = " | "): string {
 
 type ZodI18nMapOption = {
   t?: i18n["t"];
+  ns?: string | readonly string[];
   handlePath?: HandlePathOption;
 };
 
@@ -30,12 +31,13 @@ const defaultNs = "zod";
 export const makeZodI18nMap =
   (option?: ZodI18nMapOption): ZodErrorMap =>
   (issue, ctx) => {
-    const { t, handlePath } = {
+    const { t, ns, handlePath } = {
       t: i18next.t,
+      ns: defaultNs,
       ...option,
       handlePath: {
         context: "with_path",
-        ns: defaultNs,
+        ns: option?.ns ?? defaultNs,
         keyPrefix: undefined,
         ...option?.handlePath,
       },
@@ -64,7 +66,7 @@ export const makeZodI18nMap =
       case ZodIssueCode.invalid_type:
         if (issue.received === ZodParsedType.undefined) {
           message = t("errors.invalid_type_received_undefined", {
-            ns: defaultNs,
+            ns,
             defaultValue: message,
             ...path,
           });
@@ -72,13 +74,13 @@ export const makeZodI18nMap =
           message = t("errors.invalid_type", {
             expected: t(`types.${issue.expected}`, {
               defaultValue: issue.expected,
-              ns: defaultNs,
+              ns,
             }),
             received: t(`types.${issue.received}`, {
               defaultValue: issue.received,
-              ns: defaultNs,
+              ns,
             }),
-            ns: defaultNs,
+            ns,
             defaultValue: message,
             ...path,
           });
@@ -87,7 +89,7 @@ export const makeZodI18nMap =
       case ZodIssueCode.invalid_literal:
         message = t("errors.invalid_literal", {
           expected: JSON.stringify(issue.expected, jsonStringifyReplacer),
-          ns: defaultNs,
+          ns,
           defaultValue: message,
           ...path,
         });
@@ -95,14 +97,14 @@ export const makeZodI18nMap =
       case ZodIssueCode.unrecognized_keys:
         message = t("errors.unrecognized_keys", {
           keys: joinValues(issue.keys, ", "),
-          ns: defaultNs,
+          ns,
           defaultValue: message,
           ...path,
         });
         break;
       case ZodIssueCode.invalid_union:
         message = t("errors.invalid_union", {
-          ns: defaultNs,
+          ns,
           defaultValue: message,
           ...path,
         });
@@ -110,7 +112,7 @@ export const makeZodI18nMap =
       case ZodIssueCode.invalid_union_discriminator:
         message = t("errors.invalid_union_discriminator", {
           options: joinValues(issue.options),
-          ns: defaultNs,
+          ns,
           defaultValue: message,
           ...path,
         });
@@ -119,28 +121,28 @@ export const makeZodI18nMap =
         message = t("errors.invalid_enum_value", {
           options: joinValues(issue.options),
           received: issue.received,
-          ns: defaultNs,
+          ns,
           defaultValue: message,
           ...path,
         });
         break;
       case ZodIssueCode.invalid_arguments:
         message = t("errors.invalid_arguments", {
-          ns: defaultNs,
+          ns,
           defaultValue: message,
           ...path,
         });
         break;
       case ZodIssueCode.invalid_return_type:
         message = t("errors.invalid_return_type", {
-          ns: defaultNs,
+          ns,
           defaultValue: message,
           ...path,
         });
         break;
       case ZodIssueCode.invalid_date:
         message = t("errors.invalid_date", {
-          ns: defaultNs,
+          ns,
           defaultValue: message,
           ...path,
         });
@@ -150,14 +152,14 @@ export const makeZodI18nMap =
           if ("startsWith" in issue.validation) {
             message = t(`errors.invalid_string.startsWith`, {
               startsWith: issue.validation.startsWith,
-              ns: defaultNs,
+              ns,
               defaultValue: message,
               ...path,
             });
           } else if ("endsWith" in issue.validation) {
             message = t(`errors.invalid_string.endsWith`, {
               endsWith: issue.validation.endsWith,
-              ns: defaultNs,
+              ns,
               defaultValue: message,
               ...path,
             });
@@ -166,9 +168,9 @@ export const makeZodI18nMap =
           message = t(`errors.invalid_string.${issue.validation}`, {
             validation: t(`validations.${issue.validation}`, {
               defaultValue: issue.validation,
-              ns: defaultNs,
+              ns,
             }),
-            ns: defaultNs,
+            ns,
             defaultValue: message,
             ...path,
           });
@@ -186,7 +188,7 @@ export const makeZodI18nMap =
           {
             minimum:
               issue.type === "date" ? new Date(issue.minimum) : issue.minimum,
-            ns: defaultNs,
+            ns,
             defaultValue: message,
             ...path,
           }
@@ -204,7 +206,7 @@ export const makeZodI18nMap =
           {
             maximum:
               issue.type === "date" ? new Date(issue.maximum) : issue.maximum,
-            ns: defaultNs,
+            ns,
             defaultValue: message,
             ...path,
           }
@@ -212,14 +214,14 @@ export const makeZodI18nMap =
         break;
       case ZodIssueCode.custom:
         message = t("errors.custom", {
-          ns: defaultNs,
+          ns,
           defaultValue: message,
           ...path,
         });
         break;
       case ZodIssueCode.invalid_intersection_types:
         message = t("errors.invalid_intersection_types", {
-          ns: defaultNs,
+          ns,
           defaultValue: message,
           ...path,
         });
@@ -227,14 +229,14 @@ export const makeZodI18nMap =
       case ZodIssueCode.not_multiple_of:
         message = t("errors.not_multiple_of", {
           multipleOf: issue.multipleOf,
-          ns: defaultNs,
+          ns,
           defaultValue: message,
           ...path,
         });
         break;
       case ZodIssueCode.not_finite:
         message = t("errors.not_finite", {
-          ns: defaultNs,
+          ns,
           defaultValue: message,
           ...path,
         });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,13 +14,15 @@ function joinValues<T extends any[]>(array: T, separator = " | "): string {
     .join(separator);
 }
 
-type ZodI18nMapOption = {
+export type MakeZodI18nMap = (option?: ZodI18nMapOption) => ZodErrorMap;
+
+export type ZodI18nMapOption = {
   t?: i18n["t"];
   ns?: string | readonly string[];
   handlePath?: HandlePathOption;
 };
 
-type HandlePathOption = {
+export type HandlePathOption = {
   context?: string;
   ns?: string | readonly string[];
   keyPrefix?: string;
@@ -28,223 +30,221 @@ type HandlePathOption = {
 
 const defaultNs = "zod";
 
-export const makeZodI18nMap =
-  (option?: ZodI18nMapOption): ZodErrorMap =>
-  (issue, ctx) => {
-    const { t, ns, handlePath } = {
-      t: i18next.t,
-      ns: defaultNs,
-      ...option,
-      handlePath: {
-        context: "with_path",
-        ns: option?.ns ?? defaultNs,
-        keyPrefix: undefined,
-        ...option?.handlePath,
-      },
-    };
-
-    let message: string;
-    message = defaultErrorMap(issue, ctx).message;
-
-    const path =
-      issue.path.length > 0
-        ? {
-            context: handlePath.context,
-            path: t(
-              [handlePath.keyPrefix, issue.path.join(".")]
-                .filter(Boolean)
-                .join("."),
-              {
-                ns: handlePath.ns,
-                defaultValue: issue.path.join("."),
-              }
-            ),
-          }
-        : {};
-
-    switch (issue.code) {
-      case ZodIssueCode.invalid_type:
-        if (issue.received === ZodParsedType.undefined) {
-          message = t("errors.invalid_type_received_undefined", {
-            ns,
-            defaultValue: message,
-            ...path,
-          });
-        } else {
-          message = t("errors.invalid_type", {
-            expected: t(`types.${issue.expected}`, {
-              defaultValue: issue.expected,
-              ns,
-            }),
-            received: t(`types.${issue.received}`, {
-              defaultValue: issue.received,
-              ns,
-            }),
-            ns,
-            defaultValue: message,
-            ...path,
-          });
-        }
-        break;
-      case ZodIssueCode.invalid_literal:
-        message = t("errors.invalid_literal", {
-          expected: JSON.stringify(issue.expected, jsonStringifyReplacer),
-          ns,
-          defaultValue: message,
-          ...path,
-        });
-        break;
-      case ZodIssueCode.unrecognized_keys:
-        message = t("errors.unrecognized_keys", {
-          keys: joinValues(issue.keys, ", "),
-          ns,
-          defaultValue: message,
-          ...path,
-        });
-        break;
-      case ZodIssueCode.invalid_union:
-        message = t("errors.invalid_union", {
-          ns,
-          defaultValue: message,
-          ...path,
-        });
-        break;
-      case ZodIssueCode.invalid_union_discriminator:
-        message = t("errors.invalid_union_discriminator", {
-          options: joinValues(issue.options),
-          ns,
-          defaultValue: message,
-          ...path,
-        });
-        break;
-      case ZodIssueCode.invalid_enum_value:
-        message = t("errors.invalid_enum_value", {
-          options: joinValues(issue.options),
-          received: issue.received,
-          ns,
-          defaultValue: message,
-          ...path,
-        });
-        break;
-      case ZodIssueCode.invalid_arguments:
-        message = t("errors.invalid_arguments", {
-          ns,
-          defaultValue: message,
-          ...path,
-        });
-        break;
-      case ZodIssueCode.invalid_return_type:
-        message = t("errors.invalid_return_type", {
-          ns,
-          defaultValue: message,
-          ...path,
-        });
-        break;
-      case ZodIssueCode.invalid_date:
-        message = t("errors.invalid_date", {
-          ns,
-          defaultValue: message,
-          ...path,
-        });
-        break;
-      case ZodIssueCode.invalid_string:
-        if (typeof issue.validation === "object") {
-          if ("startsWith" in issue.validation) {
-            message = t(`errors.invalid_string.startsWith`, {
-              startsWith: issue.validation.startsWith,
-              ns,
-              defaultValue: message,
-              ...path,
-            });
-          } else if ("endsWith" in issue.validation) {
-            message = t(`errors.invalid_string.endsWith`, {
-              endsWith: issue.validation.endsWith,
-              ns,
-              defaultValue: message,
-              ...path,
-            });
-          }
-        } else {
-          message = t(`errors.invalid_string.${issue.validation}`, {
-            validation: t(`validations.${issue.validation}`, {
-              defaultValue: issue.validation,
-              ns,
-            }),
-            ns,
-            defaultValue: message,
-            ...path,
-          });
-        }
-        break;
-      case ZodIssueCode.too_small:
-        message = t(
-          `errors.too_small.${issue.type}.${
-            issue.exact
-              ? "exact"
-              : issue.inclusive
-              ? "inclusive"
-              : "not_inclusive"
-          }`,
-          {
-            minimum:
-              issue.type === "date" ? new Date(issue.minimum) : issue.minimum,
-            ns,
-            defaultValue: message,
-            ...path,
-          }
-        );
-        break;
-      case ZodIssueCode.too_big:
-        message = t(
-          `errors.too_big.${issue.type}.${
-            issue.exact
-              ? "exact"
-              : issue.inclusive
-              ? "inclusive"
-              : "not_inclusive"
-          }`,
-          {
-            maximum:
-              issue.type === "date" ? new Date(issue.maximum) : issue.maximum,
-            ns,
-            defaultValue: message,
-            ...path,
-          }
-        );
-        break;
-      case ZodIssueCode.custom:
-        message = t("errors.custom", {
-          ns,
-          defaultValue: message,
-          ...path,
-        });
-        break;
-      case ZodIssueCode.invalid_intersection_types:
-        message = t("errors.invalid_intersection_types", {
-          ns,
-          defaultValue: message,
-          ...path,
-        });
-        break;
-      case ZodIssueCode.not_multiple_of:
-        message = t("errors.not_multiple_of", {
-          multipleOf: issue.multipleOf,
-          ns,
-          defaultValue: message,
-          ...path,
-        });
-        break;
-      case ZodIssueCode.not_finite:
-        message = t("errors.not_finite", {
-          ns,
-          defaultValue: message,
-          ...path,
-        });
-        break;
-      default:
-    }
-
-    return { message };
+export const makeZodI18nMap: MakeZodI18nMap = (option) => (issue, ctx) => {
+  const { t, ns, handlePath } = {
+    t: i18next.t,
+    ns: defaultNs,
+    ...option,
+    handlePath: {
+      context: "with_path",
+      ns: option?.ns ?? defaultNs,
+      keyPrefix: undefined,
+      ...option?.handlePath,
+    },
   };
+
+  let message: string;
+  message = defaultErrorMap(issue, ctx).message;
+
+  const path =
+    issue.path.length > 0
+      ? {
+          context: handlePath.context,
+          path: t(
+            [handlePath.keyPrefix, issue.path.join(".")]
+              .filter(Boolean)
+              .join("."),
+            {
+              ns: handlePath.ns,
+              defaultValue: issue.path.join("."),
+            }
+          ),
+        }
+      : {};
+
+  switch (issue.code) {
+    case ZodIssueCode.invalid_type:
+      if (issue.received === ZodParsedType.undefined) {
+        message = t("errors.invalid_type_received_undefined", {
+          ns,
+          defaultValue: message,
+          ...path,
+        });
+      } else {
+        message = t("errors.invalid_type", {
+          expected: t(`types.${issue.expected}`, {
+            defaultValue: issue.expected,
+            ns,
+          }),
+          received: t(`types.${issue.received}`, {
+            defaultValue: issue.received,
+            ns,
+          }),
+          ns,
+          defaultValue: message,
+          ...path,
+        });
+      }
+      break;
+    case ZodIssueCode.invalid_literal:
+      message = t("errors.invalid_literal", {
+        expected: JSON.stringify(issue.expected, jsonStringifyReplacer),
+        ns,
+        defaultValue: message,
+        ...path,
+      });
+      break;
+    case ZodIssueCode.unrecognized_keys:
+      message = t("errors.unrecognized_keys", {
+        keys: joinValues(issue.keys, ", "),
+        ns,
+        defaultValue: message,
+        ...path,
+      });
+      break;
+    case ZodIssueCode.invalid_union:
+      message = t("errors.invalid_union", {
+        ns,
+        defaultValue: message,
+        ...path,
+      });
+      break;
+    case ZodIssueCode.invalid_union_discriminator:
+      message = t("errors.invalid_union_discriminator", {
+        options: joinValues(issue.options),
+        ns,
+        defaultValue: message,
+        ...path,
+      });
+      break;
+    case ZodIssueCode.invalid_enum_value:
+      message = t("errors.invalid_enum_value", {
+        options: joinValues(issue.options),
+        received: issue.received,
+        ns,
+        defaultValue: message,
+        ...path,
+      });
+      break;
+    case ZodIssueCode.invalid_arguments:
+      message = t("errors.invalid_arguments", {
+        ns,
+        defaultValue: message,
+        ...path,
+      });
+      break;
+    case ZodIssueCode.invalid_return_type:
+      message = t("errors.invalid_return_type", {
+        ns,
+        defaultValue: message,
+        ...path,
+      });
+      break;
+    case ZodIssueCode.invalid_date:
+      message = t("errors.invalid_date", {
+        ns,
+        defaultValue: message,
+        ...path,
+      });
+      break;
+    case ZodIssueCode.invalid_string:
+      if (typeof issue.validation === "object") {
+        if ("startsWith" in issue.validation) {
+          message = t(`errors.invalid_string.startsWith`, {
+            startsWith: issue.validation.startsWith,
+            ns,
+            defaultValue: message,
+            ...path,
+          });
+        } else if ("endsWith" in issue.validation) {
+          message = t(`errors.invalid_string.endsWith`, {
+            endsWith: issue.validation.endsWith,
+            ns,
+            defaultValue: message,
+            ...path,
+          });
+        }
+      } else {
+        message = t(`errors.invalid_string.${issue.validation}`, {
+          validation: t(`validations.${issue.validation}`, {
+            defaultValue: issue.validation,
+            ns,
+          }),
+          ns,
+          defaultValue: message,
+          ...path,
+        });
+      }
+      break;
+    case ZodIssueCode.too_small:
+      message = t(
+        `errors.too_small.${issue.type}.${
+          issue.exact
+            ? "exact"
+            : issue.inclusive
+            ? "inclusive"
+            : "not_inclusive"
+        }`,
+        {
+          minimum:
+            issue.type === "date" ? new Date(issue.minimum) : issue.minimum,
+          ns,
+          defaultValue: message,
+          ...path,
+        }
+      );
+      break;
+    case ZodIssueCode.too_big:
+      message = t(
+        `errors.too_big.${issue.type}.${
+          issue.exact
+            ? "exact"
+            : issue.inclusive
+            ? "inclusive"
+            : "not_inclusive"
+        }`,
+        {
+          maximum:
+            issue.type === "date" ? new Date(issue.maximum) : issue.maximum,
+          ns,
+          defaultValue: message,
+          ...path,
+        }
+      );
+      break;
+    case ZodIssueCode.custom:
+      message = t("errors.custom", {
+        ns,
+        defaultValue: message,
+        ...path,
+      });
+      break;
+    case ZodIssueCode.invalid_intersection_types:
+      message = t("errors.invalid_intersection_types", {
+        ns,
+        defaultValue: message,
+        ...path,
+      });
+      break;
+    case ZodIssueCode.not_multiple_of:
+      message = t("errors.not_multiple_of", {
+        multipleOf: issue.multipleOf,
+        ns,
+        defaultValue: message,
+        ...path,
+      });
+      break;
+    case ZodIssueCode.not_finite:
+      message = t("errors.not_finite", {
+        ns,
+        defaultValue: message,
+        ...path,
+      });
+      break;
+    default:
+  }
+
+  return { message };
+};
 
 export const zodI18nMap = makeZodI18nMap();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,100 +14,169 @@ function joinValues<T extends any[]>(array: T, separator = " | "): string {
     .join(separator);
 }
 
+type ZodI18nMapOption = {
+  t?: i18n["t"];
+  handlePath?: HandlePathOption;
+};
+
+type HandlePathOption = {
+  context?: string;
+  ns?: string | readonly string[];
+  keyPrefix?: string;
+};
+
+const defaultNs = "zod";
+
 export const makeZodI18nMap =
-  (t: i18n["t"] = i18next.t): ZodErrorMap =>
+  (option?: ZodI18nMapOption): ZodErrorMap =>
   (issue, ctx) => {
+    const { t, handlePath } = {
+      t: i18next.t,
+      ...option,
+      handlePath: {
+        context: "with_path",
+        ns: defaultNs,
+        keyPrefix: undefined,
+        ...option?.handlePath,
+      },
+    };
+
     let message: string;
     message = defaultErrorMap(issue, ctx).message;
+
+    const path =
+      issue.path.length > 0
+        ? {
+            context: handlePath.context,
+            path: t(
+              [handlePath.keyPrefix, issue.path.join(".")]
+                .filter(Boolean)
+                .join("."),
+              {
+                ns: handlePath.ns,
+                defaultValue: issue.path.join("."),
+              }
+            ),
+          }
+        : {};
 
     switch (issue.code) {
       case ZodIssueCode.invalid_type:
         if (issue.received === ZodParsedType.undefined) {
-          message = t("zod:errors.invalid_type_received_undefined", {
+          message = t("errors.invalid_type_received_undefined", {
+            ns: defaultNs,
             defaultValue: message,
+            ...path,
           });
         } else {
-          message = t("zod:errors.invalid_type", {
-            expected: `$t(zod:types.${issue.expected})`,
-            received: `$t(zod:types.${issue.received})`,
+          message = t("errors.invalid_type", {
+            expected: t(`types.${issue.expected}`, {
+              defaultValue: issue.expected,
+              ns: defaultNs,
+            }),
+            received: t(`types.${issue.received}`, {
+              defaultValue: issue.received,
+              ns: defaultNs,
+            }),
+            ns: defaultNs,
             defaultValue: message,
-            interpolation: {
-              skipOnVariables: false,
-            },
+            ...path,
           });
         }
         break;
       case ZodIssueCode.invalid_literal:
-        message = t("zod:errors.invalid_literal", {
+        message = t("errors.invalid_literal", {
           expected: JSON.stringify(issue.expected, jsonStringifyReplacer),
+          ns: defaultNs,
           defaultValue: message,
+          ...path,
         });
         break;
       case ZodIssueCode.unrecognized_keys:
-        message = t("zod:errors.unrecognized_keys", {
+        message = t("errors.unrecognized_keys", {
           keys: joinValues(issue.keys, ", "),
+          ns: defaultNs,
           defaultValue: message,
+          ...path,
         });
         break;
       case ZodIssueCode.invalid_union:
-        message = t("zod:errors.invalid_union", {
+        message = t("errors.invalid_union", {
+          ns: defaultNs,
           defaultValue: message,
+          ...path,
         });
         break;
       case ZodIssueCode.invalid_union_discriminator:
-        message = t("zod:errors.invalid_union_discriminator", {
+        message = t("errors.invalid_union_discriminator", {
           options: joinValues(issue.options),
+          ns: defaultNs,
           defaultValue: message,
+          ...path,
         });
         break;
       case ZodIssueCode.invalid_enum_value:
-        message = t("zod:errors.invalid_enum_value", {
+        message = t("errors.invalid_enum_value", {
           options: joinValues(issue.options),
           received: issue.received,
+          ns: defaultNs,
           defaultValue: message,
+          ...path,
         });
         break;
       case ZodIssueCode.invalid_arguments:
-        message = t("zod:errors.invalid_arguments", {
+        message = t("errors.invalid_arguments", {
+          ns: defaultNs,
           defaultValue: message,
+          ...path,
         });
         break;
       case ZodIssueCode.invalid_return_type:
-        message = t("zod:errors.invalid_return_type", {
+        message = t("errors.invalid_return_type", {
+          ns: defaultNs,
           defaultValue: message,
+          ...path,
         });
         break;
       case ZodIssueCode.invalid_date:
-        message = t("zod:errors.invalid_date", {
+        message = t("errors.invalid_date", {
+          ns: defaultNs,
           defaultValue: message,
+          ...path,
         });
         break;
       case ZodIssueCode.invalid_string:
         if (typeof issue.validation === "object") {
           if ("startsWith" in issue.validation) {
-            message = t(`zod:errors.invalid_string.startsWith`, {
+            message = t(`errors.invalid_string.startsWith`, {
               startsWith: issue.validation.startsWith,
+              ns: defaultNs,
               defaultValue: message,
+              ...path,
             });
           } else if ("endsWith" in issue.validation) {
-            message = t(`zod:errors.invalid_string.endsWith`, {
+            message = t(`errors.invalid_string.endsWith`, {
               endsWith: issue.validation.endsWith,
+              ns: defaultNs,
               defaultValue: message,
+              ...path,
             });
           }
         } else {
-          message = t(`zod:errors.invalid_string.${issue.validation}`, {
-            validation: `$t(zod:validations.${issue.validation})`,
+          message = t(`errors.invalid_string.${issue.validation}`, {
+            validation: t(`validations.${issue.validation}`, {
+              defaultValue: issue.validation,
+              ns: defaultNs,
+            }),
+            ns: defaultNs,
             defaultValue: message,
-            interpolation: {
-              skipOnVariables: false,
-            },
+            ...path,
           });
         }
         break;
       case ZodIssueCode.too_small:
         message = t(
-          `zod:errors.too_small.${issue.type}.${
+          `errors.too_small.${issue.type}.${
             issue.exact
               ? "exact"
               : issue.inclusive
@@ -117,13 +186,15 @@ export const makeZodI18nMap =
           {
             minimum:
               issue.type === "date" ? new Date(issue.minimum) : issue.minimum,
+            ns: defaultNs,
             defaultValue: message,
+            ...path,
           }
         );
         break;
       case ZodIssueCode.too_big:
         message = t(
-          `zod:errors.too_big.${issue.type}.${
+          `errors.too_big.${issue.type}.${
             issue.exact
               ? "exact"
               : issue.inclusive
@@ -133,29 +204,39 @@ export const makeZodI18nMap =
           {
             maximum:
               issue.type === "date" ? new Date(issue.maximum) : issue.maximum,
+            ns: defaultNs,
             defaultValue: message,
+            ...path,
           }
         );
         break;
       case ZodIssueCode.custom:
-        message = t("zod:errors.custom", {
+        message = t("errors.custom", {
+          ns: defaultNs,
           defaultValue: message,
+          ...path,
         });
         break;
       case ZodIssueCode.invalid_intersection_types:
-        message = t("zod:errors.invalid_intersection_types", {
+        message = t("errors.invalid_intersection_types", {
+          ns: defaultNs,
           defaultValue: message,
+          ...path,
         });
         break;
       case ZodIssueCode.not_multiple_of:
-        message = t("zod:errors.not_multiple_of", {
+        message = t("errors.not_multiple_of", {
           multipleOf: issue.multipleOf,
+          ns: defaultNs,
           defaultValue: message,
+          ...path,
         });
         break;
       case ZodIssueCode.not_finite:
-        message = t("zod:errors.not_finite", {
+        message = t("errors.not_finite", {
+          ns: defaultNs,
           defaultValue: message,
+          ...path,
         });
         break;
       default:

--- a/packages/core/tests/handlePath.test.ts
+++ b/packages/core/tests/handlePath.test.ts
@@ -1,0 +1,139 @@
+import { test, expect, describe } from "vitest";
+import { z } from "zod";
+import { makeZodI18nMap } from "../src";
+import * as i18next from "i18next";
+import { getErrorMessage } from "./helpers";
+
+describe("Handling key of object schema", () => {
+  test("default context, ns, and keyPrefix", async () => {
+    await i18next.init({
+      lng: "en",
+      resources: {
+        en: {
+          zod: {
+            errors: {
+              invalid_type: "Expected {{expected}}, received {{received}}",
+              invalid_type_with_path:
+                "{{- path}} is expected {{expected}}, received {{received}}",
+            },
+            userName: "user's name",
+          },
+        },
+      },
+    });
+    z.setErrorMap(makeZodI18nMap());
+
+    const schema = z.object({
+      userName: z.string(),
+    });
+
+    expect(getErrorMessage(schema.safeParse({ userName: 5 }))).toEqual(
+      "user's name is expected string, received number"
+    );
+  });
+
+  test("custom context", async () => {
+    await i18next.init({
+      lng: "en",
+      resources: {
+        en: {
+          zod: {
+            errors: {
+              invalid_type: "Expected {{expected}}, received {{received}}",
+              invalid_type_custom_context:
+                "{{- path}} is expected {{expected}}, received {{received}}",
+            },
+            userName: "user's name",
+          },
+        },
+      },
+    });
+    z.setErrorMap(
+      makeZodI18nMap({ handlePath: { context: "custom_context" } })
+    );
+
+    const schema = z.object({
+      userName: z.string(),
+    });
+
+    expect(getErrorMessage(schema.safeParse({ userName: 5 }))).toEqual(
+      "user's name is expected string, received number"
+    );
+
+    z.setErrorMap(makeZodI18nMap());
+    // fallback
+    expect(getErrorMessage(schema.safeParse({ userName: 5 }))).toEqual(
+      "Expected string, received number"
+    );
+  });
+
+  test("custom ns", async () => {
+    await i18next.init({
+      lng: "en",
+      resources: {
+        en: {
+          common: {
+            userName: "user's name",
+          },
+          zod: {
+            errors: {
+              invalid_type: "Expected {{expected}}, received {{received}}",
+              invalid_type_with_path:
+                "{{- path}} is expected {{expected}}, received {{received}}",
+            },
+          },
+        },
+      },
+    });
+    z.setErrorMap(makeZodI18nMap({ handlePath: { ns: "common" } }));
+
+    const schema = z.object({
+      userName: z.string(),
+    });
+
+    expect(getErrorMessage(schema.safeParse({ userName: 5 }))).toEqual(
+      "user's name is expected string, received number"
+    );
+
+    z.setErrorMap(makeZodI18nMap());
+    // fallback
+    expect(getErrorMessage(schema.safeParse({ userName: 5 }))).toEqual(
+      "userName is expected string, received number"
+    );
+  });
+
+  test("custom keyPrefix", async () => {
+    await i18next.init({
+      lng: "en",
+      resources: {
+        en: {
+          zod: {
+            errors: {
+              invalid_type: "Expected {{expected}}, received {{received}}",
+              invalid_type_with_path:
+                "{{- path}} is expected {{expected}}, received {{received}}",
+            },
+            paths: {
+              userName: "user's name",
+            },
+          },
+        },
+      },
+    });
+    z.setErrorMap(makeZodI18nMap({ handlePath: { keyPrefix: "paths" } }));
+
+    const schema = z.object({
+      userName: z.string(),
+    });
+
+    expect(getErrorMessage(schema.safeParse({ userName: 5 }))).toEqual(
+      "user's name is expected string, received number"
+    );
+
+    z.setErrorMap(makeZodI18nMap());
+    // fallback
+    expect(getErrorMessage(schema.safeParse({ userName: 5 }))).toEqual(
+      "userName is expected string, received number"
+    );
+  });
+});

--- a/packages/core/tests/helpers.ts
+++ b/packages/core/tests/helpers.ts
@@ -1,0 +1,19 @@
+import { SafeParseReturnType, ZodError } from "zod";
+
+export const getErrorMessage = (
+  parsed: SafeParseReturnType<unknown, unknown>
+): string => {
+  if ("error" in parsed) return parsed.error.issues[0].message;
+  throw new Error();
+};
+
+export const getErrorMessageFromZodError = (callback: () => void) => {
+  try {
+    callback();
+  } catch (e) {
+    if (e instanceof ZodError) {
+      return e.errors[0].message;
+    }
+    throw e;
+  }
+};

--- a/packages/core/tests/integrations/ar.test.ts
+++ b/packages/core/tests/integrations/ar.test.ts
@@ -202,4 +202,14 @@ test("other parser error messages", () => {
   expect(
     getErrorMessage(z.union([z.string(), z.number()]).safeParse([true]))
   ).toEqual("مدخل غير صالح");
+  expect(
+    getErrorMessage(
+      z
+        .string()
+        .refine(() => {
+          return false;
+        })
+        .safeParse("")
+    )
+  ).toEqual("مدخل غير صالح");
 });

--- a/packages/core/tests/integrations/en.test.ts
+++ b/packages/core/tests/integrations/en.test.ts
@@ -198,4 +198,14 @@ test("other parser error messages", () => {
   expect(
     getErrorMessage(z.union([z.string(), z.number()]).safeParse([true]))
   ).toEqual("Invalid input");
+  expect(
+    getErrorMessage(
+      z
+        .string()
+        .refine(() => {
+          return false;
+        })
+        .safeParse("")
+    )
+  ).toEqual("Invalid input");
 });

--- a/packages/core/tests/integrations/es.test.ts
+++ b/packages/core/tests/integrations/es.test.ts
@@ -196,4 +196,14 @@ test("other parser error messages", () => {
   expect(
     getErrorMessage(z.union([z.string(), z.number()]).safeParse([true]))
   ).toEqual("Entrada inválida");
+  expect(
+    getErrorMessage(
+      z
+        .string()
+        .refine(() => {
+          return false;
+        })
+        .safeParse("")
+    )
+  ).toEqual("Entrada inválida");
 });

--- a/packages/core/tests/integrations/fr.test.ts
+++ b/packages/core/tests/integrations/fr.test.ts
@@ -204,4 +204,14 @@ test("other parser error messages", () => {
   expect(
     getErrorMessage(z.union([z.string(), z.number()]).safeParse([true]))
   ).toEqual("Champ invalide");
+  expect(
+    getErrorMessage(
+      z
+        .string()
+        .refine(() => {
+          return false;
+        })
+        .safeParse("")
+    )
+  ).toEqual("Champ invalide");
 });

--- a/packages/core/tests/integrations/helpers.ts
+++ b/packages/core/tests/integrations/helpers.ts
@@ -1,5 +1,5 @@
 import * as i18next from "i18next";
-import { SafeParseReturnType, z, ZodError } from "zod";
+import { z } from "zod";
 import { zodI18nMap } from "../../src";
 
 export const init = async (lng: string) => {
@@ -13,20 +13,4 @@ export const init = async (lng: string) => {
   z.setErrorMap(zodI18nMap);
 };
 
-export const getErrorMessage = (
-  parsed: SafeParseReturnType<unknown, unknown>
-): string => {
-  if ("error" in parsed) return parsed.error.issues[0].message;
-  throw new Error();
-};
-
-export const getErrorMessageFromZodError = (callback: () => void) => {
-  try {
-    callback();
-  } catch (e) {
-    if (e instanceof ZodError) {
-      return e.errors[0].message;
-    }
-    throw e;
-  }
-};
+export * from "../helpers";

--- a/packages/core/tests/integrations/is.test.ts
+++ b/packages/core/tests/integrations/is.test.ts
@@ -200,4 +200,14 @@ test("other parser error messages", () => {
   expect(
     getErrorMessage(z.union([z.string(), z.number()]).safeParse([true]))
   ).toEqual("Ógilt inntak");
+  expect(
+    getErrorMessage(
+      z
+        .string()
+        .refine(() => {
+          return false;
+        })
+        .safeParse("")
+    )
+  ).toEqual("Ógilt inntak");
 });

--- a/packages/core/tests/integrations/ja.test.ts
+++ b/packages/core/tests/integrations/ja.test.ts
@@ -200,4 +200,14 @@ test("other parser error messages", () => {
   expect(
     getErrorMessage(z.union([z.string(), z.number()]).safeParse([true]))
   ).toEqual("入力形式が間違っています。");
+  expect(
+    getErrorMessage(
+      z
+        .string()
+        .refine(() => {
+          return false;
+        })
+        .safeParse("")
+    )
+  ).toEqual("入力形式が間違っています。");
 });

--- a/packages/core/tests/integrations/pt.test.ts
+++ b/packages/core/tests/integrations/pt.test.ts
@@ -199,4 +199,14 @@ test("other parser error messages", () => {
   expect(
     getErrorMessage(z.union([z.string(), z.number()]).safeParse([true]))
   ).toEqual("Entrada inválida");
+  expect(
+    getErrorMessage(
+      z
+        .string()
+        .refine(() => {
+          return false;
+        })
+        .safeParse("")
+    )
+  ).toEqual("Entrada inválida");
 });

--- a/packages/core/tests/integrations/zh-CN.test.ts
+++ b/packages/core/tests/integrations/zh-CN.test.ts
@@ -189,4 +189,14 @@ test("other parser error messages", () => {
   expect(
     getErrorMessage(z.union([z.string(), z.number()]).safeParse([true]))
   ).toEqual("输入格式错误");
+  expect(
+    getErrorMessage(
+      z
+        .string()
+        .refine(() => {
+          return false;
+        })
+        .safeParse("")
+    )
+  ).toEqual("格式错误");
 });

--- a/packages/core/tests/makeZodI18nMap.test.ts
+++ b/packages/core/tests/makeZodI18nMap.test.ts
@@ -171,3 +171,11 @@ describe("Handling key of object schema", () => {
     );
   });
 });
+
+describe("jsonStringifyReplacer", () => {
+  test("include bigint", async () => {
+    expect(
+      getErrorMessage(z.literal(BigInt(9007199254740991)).safeParse(""))
+    ).toEqual('Invalid literal value, expected "9007199254740991"');
+  });
+});

--- a/packages/core/tests/makeZodI18nMap.test.ts
+++ b/packages/core/tests/makeZodI18nMap.test.ts
@@ -4,6 +4,40 @@ import { makeZodI18nMap } from "../src";
 import * as i18next from "i18next";
 import { getErrorMessage } from "./helpers";
 
+describe("ns", () => {
+  test("changeable ns", async () => {
+    await i18next.init({
+      lng: "en",
+      resources: {
+        en: {
+          zod: {
+            errors: {
+              invalid_type: "Expected {{expected}}, received {{received}}",
+            },
+          },
+          zod2: {
+            errors: {
+              invalid_type:
+                "Error: it is expected to provide {{expected}} but you provided {{received}}",
+            },
+          },
+        },
+      },
+    });
+    z.setErrorMap(makeZodI18nMap());
+
+    expect(getErrorMessage(z.string().safeParse(5))).toEqual(
+      "Expected string, received number"
+    );
+
+    z.setErrorMap(makeZodI18nMap({ ns: "zod2" }));
+
+    expect(getErrorMessage(z.string().safeParse(5))).toEqual(
+      "Error: it is expected to provide string but you provided number"
+    );
+  });
+});
+
 describe("Handling key of object schema", () => {
   test("default context, ns, and keyPrefix", async () => {
     await i18next.init({


### PR DESCRIPTION
- [x] update README
- [x] update example

## feat: handling object schema keys in error messages
```ts
i18next.init({
  lng: "en",
  resources: {
    en: {
      zod: {
        errors: {
          invalid_type: "Expected {{expected}}, received {{received}}",
          invalid_type_with_path:
            "{{- path}} is expected {{expected}}, received {{received}}",
        },
        userName: "user's name",
      },
    },
  },
});

z.setErrorMap(zodI18nMap);

const schema = z.object({
  userName: z.string(),
});

z.string().safeParse(5) // "Expected string, received number"
schema.safeParse({ userName: 5 }) // "user's name is expected string, received number"
```

## feat: enable switching namespace
```ts
i18next.init({
  lng: "en",
  resources: {
    en: {
      zod: {
        errors: {
          invalid_type: "Expected {{expected}}, received {{received}}",
        },
      },
      formValidator: {
        errors: {
          invalid_type: "Error: it is expected to provide {{expected}} but you provided {{received}}",
        },
      },
    },
  },
});

z.setErrorMap(zodI18nMap); // => selected ns: zod
z.setErrorMap(makeZodI18nMap({ ns: 'formValidator' })); // => selected ns: formValidator
```
