### PR TITLE
feat(language): add norwegian (bokmaal) language

### DIFF
--- a/examples/with-next-i18next/next-i18next.config.js
+++ b/examples/with-next-i18next/next-i18next.config.js
@@ -16,6 +16,7 @@ module.exports = {
       "is",
       "es",
       "nl",
+      "nb",
       "de",
       "it",
       "tr",

--- a/examples/with-next-i18next/pages/index.tsx
+++ b/examples/with-next-i18next/pages/index.tsx
@@ -84,6 +84,7 @@ export default function HookForm() {
             <option value="is">íslenskur</option>
             <option value="ja">日本語</option>
             <option value="nl">Nederlands</option>
+            <option value="nb">Norsk bokmål</option>
             <option value="pt">Português</option>
             <option value="pl">polski</option>
             <option value="tr">Türkçe</option>

--- a/examples/with-next-i18next/public/locales/nb/common.json
+++ b/examples/with-next-i18next/public/locales/nb/common.json
@@ -1,0 +1,7 @@
+{
+  "username": "Brukernavn",
+  "username_placeholder": "Ola Normann",
+  "email": "Epost",
+  "favoriteNumber": "Favorittnummer",
+  "submit": "Send"
+}

--- a/examples/with-next-i18next/public/locales/nb/zod.json
+++ b/examples/with-next-i18next/public/locales/nb/zod.json
@@ -1,0 +1,112 @@
+{
+  "errors": {
+    "invalid_type": "Forventet {{expected}}, mottok {{received}}",
+    "invalid_type_received_undefined": "Må ikke være tom",
+    "invalid_literal": "Ugyldig bokstavlig verdi, forventet {{expected}}",
+    "unrecognized_keys": "Ukjent nøkkel i objektet: {{- keys}}",
+    "invalid_union": "Ugyldig inndata",
+    "invalid_union_discriminator": "Ugyldig diskriminatorverdi, forventet {{- options}}",
+    "invalid_enum_value": "Ugyldig enum-verdi. Forventet {{- options}}, mottatt '{{received}}'",
+    "invalid_arguments": "Ugyldige funksjonsargumenter",
+    "invalid_return_type": "Ugyldig returtype",
+    "invalid_date": "Ugyldig dato",
+    "custom": "Ugyldig inndata",
+    "invalid_intersection_types": "Kryssresultater kunne ikke slås sammen",
+    "not_multiple_of": "Tallet må være et multiplum av {{multipleOf}}",
+    "not_finite": "Tallet må være endelig",
+    "invalid_string": {
+      "email": "Ugyldig {{validation}}",
+      "url": "Ugyldig {{validation}}",
+      "uuid": "Ugyldig {{validation}}",
+      "cuid": "Ugyldig {{validation}}",
+      "regex": "Ugyldig",
+      "datetime": "Ugyldig {{validation}}",
+      "startsWith": "Ugyldig inndata: må starte med \"{{startsWith}}\"",
+      "endsWith": "Ugyldig inndata: må slutte med \"{{endsWith}}\""
+    },
+    "too_small": {
+      "array": {
+        "exact": "Array må inneholde nøyaktig {{minimum}} element(er)",
+        "inclusive": "Array må inneholde minst {{minimum}} element(er)",
+        "not_inclusive": "Array må inneholde mer enn {{minimum}} element(er)"
+      },
+      "string": {
+        "exact": "Strengen må inneholde nøyaktig {{minimum}} bokstav(er)",
+        "inclusive": "Strengen må inneholde minst {{minimum}} bokstav(er)",
+        "not_inclusive": "Strengen må inneholde over {{minimum}} bokstav(er)"
+      },
+      "number": {
+        "exact": "Tallet må være nøyaktig {{minimum}}",
+        "inclusive": "Tallet må være større enn eller lik {{minimum}}",
+        "not_inclusive": "Tallet må være større enn {{minimum}}"
+      },
+      "set": {
+        "exact": "Ugyldig inndata",
+        "inclusive": "Ugyldig inndata",
+        "not_inclusive": "Ugyldig inndata"
+      },
+      "date": {
+        "exact": "Datoen må være nøyaktig {{- minimum, datetime}}",
+        "inclusive": "Datoen må være større enn eller lik {{- minimum, datetime}}",
+        "not_inclusive": "Datoen må være større enn {{- minimum, datetime}}"
+      }
+    },
+    "too_big": {
+      "array": {
+        "exact": "Array må inneholde nøyaktig {{maximum}} element(er)",
+        "inclusive": "Array må inneholde maksimalt {{maximum}} element(er)",
+        "not_inclusive": "Array må inneholde mindre enn {{maximum}} element(er)"
+      },
+      "string": {
+        "exact": "Strengen må inneholde nøyaktig {{maximum}} tegn",
+        "inclusive": "Strengen må være mindre eller lik {{maximum}} tegn",
+        "not_inclusive": "Strengen må inneholde under {{maximum}} tegn"
+      },
+      "number": {
+        "exact": "Tallet må være nøyaktig {{maximum}}",
+        "inclusive": "Tallet må være mindre enn eller lik {{maximum}}",
+        "not_inclusive": "Tallet må være mindre enn {{maximum}}"
+      },
+      "set": {
+        "exact": "Ugyldig inndata",
+        "inclusive": "Ugyldig inndata",
+        "not_inclusive": "Ugyldig inndata"
+      },
+      "date": {
+        "exact": "Datoen må være nøyaktig {{- maximum, datetime}}",
+        "inclusive": "Datoen må være mindre enn eller lik {{- maximum, datetime}}",
+        "not_inclusive": "Datoen må være mindre enn {{- maximum, datetime}}"
+      }
+    }
+  },
+  "validations": {
+    "email": "Epost adresse",
+    "url": "URL",
+    "uuid": "UUID",
+    "cuid": "CUID",
+    "regex": "Eegex",
+    "datetime": "Dato og klokkeslett"
+  },
+  "types": {
+    "function": "Funksjon",
+    "number": "Nummer",
+    "string": "String",
+    "nan": "NaN",
+    "integer": "Heltall",
+    "float": "Flyttall",
+    "boolean": "Boolean",
+    "date": "Dato",
+    "bigint": "Bigint",
+    "undefined": "Undefined",
+    "symbol": "Symbol",
+    "null": "Null",
+    "array": "Array",
+    "object": "Objekt",
+    "unknown": "Unknown",
+    "promise": "Promise",
+    "void": "Void",
+    "never": "Never",
+    "map": "Map",
+    "set": "Set"
+  }
+}

--- a/packages/core/locales/nb/zod.json
+++ b/packages/core/locales/nb/zod.json
@@ -1,0 +1,112 @@
+{
+  "errors": {
+    "invalid_type": "Forventet {{expected}}, mottok {{received}}",
+    "invalid_type_received_undefined": "Må ikke være tom",
+    "invalid_literal": "Ugyldig bokstavlig verdi, forventet {{expected}}",
+    "unrecognized_keys": "Ukjent nøkkel i objektet: {{- keys}}",
+    "invalid_union": "Ugyldig inndata",
+    "invalid_union_discriminator": "Ugyldig diskriminatorverdi, forventet {{- options}}",
+    "invalid_enum_value": "Ugyldig enum-verdi. Forventet {{- options}}, mottatt '{{received}}'",
+    "invalid_arguments": "Ugyldige funksjonsargumenter",
+    "invalid_return_type": "Ugyldig returtype",
+    "invalid_date": "Ugyldig dato",
+    "custom": "Ugyldig inndata",
+    "invalid_intersection_types": "Kryssresultater kunne ikke slås sammen",
+    "not_multiple_of": "Tallet må være et multiplum av {{multipleOf}}",
+    "not_finite": "Tallet må være endelig",
+    "invalid_string": {
+      "email": "Ugyldig {{validation}}",
+      "url": "Ugyldig {{validation}}",
+      "uuid": "Ugyldig {{validation}}",
+      "cuid": "Ugyldig {{validation}}",
+      "regex": "Ugyldig",
+      "datetime": "Ugyldig {{validation}}",
+      "startsWith": "Ugyldig inndata: må starte med \"{{startsWith}}\"",
+      "endsWith": "Ugyldig inndata: må slutte med \"{{endsWith}}\""
+    },
+    "too_small": {
+      "array": {
+        "exact": "Array må inneholde nøyaktig {{minimum}} element(er)",
+        "inclusive": "Array må inneholde minst {{minimum}} element(er)",
+        "not_inclusive": "Array må inneholde mer enn {{minimum}} element(er)"
+      },
+      "string": {
+        "exact": "Strengen må inneholde nøyaktig {{minimum}} bokstav(er)",
+        "inclusive": "Strengen må inneholde minst {{minimum}} bokstav(er)",
+        "not_inclusive": "Strengen må inneholde over {{minimum}} bokstav(er)"
+      },
+      "number": {
+        "exact": "Tallet må være nøyaktig {{minimum}}",
+        "inclusive": "Tallet må være større enn eller lik {{minimum}}",
+        "not_inclusive": "Tallet må være større enn {{minimum}}"
+      },
+      "set": {
+        "exact": "Ugyldig inndata",
+        "inclusive": "Ugyldig inndata",
+        "not_inclusive": "Ugyldig inndata"
+      },
+      "date": {
+        "exact": "Datoen må være nøyaktig {{- minimum, datetime}}",
+        "inclusive": "Datoen må være større enn eller lik {{- minimum, datetime}}",
+        "not_inclusive": "Datoen må være større enn {{- minimum, datetime}}"
+      }
+    },
+    "too_big": {
+      "array": {
+        "exact": "Array må inneholde nøyaktig {{maximum}} element(er)",
+        "inclusive": "Array må inneholde maksimalt {{maximum}} element(er)",
+        "not_inclusive": "Array må inneholde mindre enn {{maximum}} element(er)"
+      },
+      "string": {
+        "exact": "Strengen må inneholde nøyaktig {{maximum}} tegn",
+        "inclusive": "Strengen må være mindre eller lik {{maximum}} tegn",
+        "not_inclusive": "Strengen må inneholde under {{maximum}} tegn"
+      },
+      "number": {
+        "exact": "Tallet må være nøyaktig {{maximum}}",
+        "inclusive": "Tallet må være mindre enn eller lik {{maximum}}",
+        "not_inclusive": "Tallet må være mindre enn {{maximum}}"
+      },
+      "set": {
+        "exact": "Ugyldig inndata",
+        "inclusive": "Ugyldig inndata",
+        "not_inclusive": "Ugyldig inndata"
+      },
+      "date": {
+        "exact": "Datoen må være nøyaktig {{- maximum, datetime}}",
+        "inclusive": "Datoen må være mindre enn eller lik {{- maximum, datetime}}",
+        "not_inclusive": "Datoen må være mindre enn {{- maximum, datetime}}"
+      }
+    }
+  },
+  "validations": {
+    "email": "Epost adresse",
+    "url": "URL",
+    "uuid": "UUID",
+    "cuid": "CUID",
+    "regex": "Eegex",
+    "datetime": "Dato og klokkeslett"
+  },
+  "types": {
+    "function": "Funksjon",
+    "number": "Nummer",
+    "string": "String",
+    "nan": "NaN",
+    "integer": "Heltall",
+    "float": "Flyttall",
+    "boolean": "Boolean",
+    "date": "Dato",
+    "bigint": "Bigint",
+    "undefined": "Undefined",
+    "symbol": "Symbol",
+    "null": "Null",
+    "array": "Array",
+    "object": "Objekt",
+    "unknown": "Unknown",
+    "promise": "Promise",
+    "void": "Void",
+    "never": "Never",
+    "map": "Map",
+    "set": "Set"
+  }
+}

--- a/packages/core/tests/integrations/nb.test.ts
+++ b/packages/core/tests/integrations/nb.test.ts
@@ -1,0 +1,211 @@
+import { beforeAll, expect, test } from "vitest";
+import { z } from "zod";
+import { getErrorMessage, getErrorMessageFromZodError, init } from "./helpers";
+
+const LOCALE = "nb";
+
+beforeAll(async () => {
+  await init(LOCALE);
+});
+
+test("string parser error messages", () => {
+  const schema = z.string();
+
+  expect(getErrorMessage(schema.safeParse(undefined))).toEqual(
+    "Må ikke være tom"
+  );
+  expect(getErrorMessage(schema.safeParse(1))).toEqual(
+    "Forventet String, mottok Nummer"
+  );
+  expect(getErrorMessage(schema.safeParse(true))).toEqual(
+    "Forventet String, mottok Boolean"
+  );
+  expect(getErrorMessage(schema.safeParse(Date))).toEqual(
+    "Forventet String, mottok Funksjon"
+  );
+  expect(getErrorMessage(schema.safeParse(new Date()))).toEqual(
+    "Forventet String, mottok Dato"
+  );
+  expect(getErrorMessage(schema.email().safeParse(""))).toEqual(
+    "Ugyldig Epost adresse"
+  );
+  expect(getErrorMessage(schema.url().safeParse(""))).toEqual("Ugyldig URL");
+  expect(getErrorMessage(schema.regex(/aaa/).safeParse(""))).toEqual("Ugyldig");
+  expect(getErrorMessage(schema.startsWith("foo").safeParse(""))).toEqual(
+    'Ugyldig inndata: må starte med "foo"'
+  );
+  expect(getErrorMessage(schema.endsWith("bar").safeParse(""))).toEqual(
+    'Ugyldig inndata: må slutte med "bar"'
+  );
+  expect(getErrorMessage(schema.min(5).safeParse("a"))).toEqual(
+    "Strengen må inneholde minst 5 bokstav(er)"
+  );
+  expect(getErrorMessage(schema.max(5).safeParse("abcdef"))).toEqual(
+    "Strengen må være mindre eller lik 5 tegn"
+  );
+  expect(getErrorMessage(schema.length(5).safeParse("abcdef"))).toEqual(
+    "Strengen må inneholde nøyaktig 5 tegn"
+  );
+  expect(
+    getErrorMessage(schema.datetime().safeParse("2020-01-01T00:00:00+02:00"))
+  ).toEqual("Ugyldig Dato og klokkeslett");
+});
+
+test("number parser error messages", () => {
+  const schema = z.number();
+
+  expect(getErrorMessage(schema.safeParse(undefined))).toEqual(
+    "Må ikke være tom"
+  );
+  expect(getErrorMessage(schema.safeParse(""))).toEqual(
+    "Forventet Nummer, mottok String"
+  );
+  expect(getErrorMessage(schema.safeParse(null))).toEqual(
+    "Forventet Nummer, mottok Null"
+  );
+  expect(getErrorMessage(schema.safeParse(NaN))).toEqual(
+    "Forventet Nummer, mottok NaN"
+  );
+  expect(getErrorMessage(schema.int().safeParse(0.1))).toEqual(
+    "Forventet Heltall, mottok Flyttall"
+  );
+  expect(getErrorMessage(schema.multipleOf(5).safeParse(2))).toEqual(
+    "Tallet må være et multiplum av 5"
+  );
+  expect(getErrorMessage(schema.step(0.1).safeParse(0.0001))).toEqual(
+    "Tallet må være et multiplum av 0.1"
+  );
+  expect(getErrorMessage(schema.lt(5).safeParse(10))).toEqual(
+    "Tallet må være mindre enn 5"
+  );
+  expect(getErrorMessage(schema.lte(5).safeParse(10))).toEqual(
+    "Tallet må være mindre enn eller lik 5"
+  );
+  expect(getErrorMessage(schema.gt(5).safeParse(1))).toEqual(
+    "Tallet må være større enn 5"
+  );
+  expect(getErrorMessage(schema.gte(5).safeParse(1))).toEqual(
+    "Tallet må være større enn eller lik 5"
+  );
+  expect(getErrorMessage(schema.nonnegative().safeParse(-1))).toEqual(
+    "Tallet må være større enn eller lik 0"
+  );
+  expect(getErrorMessage(schema.nonpositive().safeParse(1))).toEqual(
+    "Tallet må være mindre enn eller lik 0"
+  );
+  expect(getErrorMessage(schema.negative().safeParse(1))).toEqual(
+    "Tallet må være mindre enn 0"
+  );
+  expect(getErrorMessage(schema.positive().safeParse(0))).toEqual(
+    "Tallet må være større enn 0"
+  );
+  expect(getErrorMessage(schema.finite().safeParse(Infinity))).toEqual(
+    "Tallet må være endelig"
+  );
+});
+
+test("date parser error messages", async () => {
+  const testDate = new Date("2022-08-01");
+  const schema = z.date();
+
+  expect(getErrorMessage(schema.safeParse("2022-12-01"))).toEqual(
+    "Forventet Dato, mottok String"
+  );
+  expect(
+    getErrorMessage(schema.min(testDate).safeParse(new Date("2022-07-29")))
+  ).toEqual(
+    `Datoen må være større enn eller lik ${testDate.toLocaleDateString(LOCALE)}`
+  );
+  expect(
+    getErrorMessage(schema.max(testDate).safeParse(new Date("2022-08-02")))
+  ).toEqual(
+    `Datoen må være mindre enn eller lik ${testDate.toLocaleDateString(LOCALE)}`
+  );
+  try {
+    await schema.parseAsync(new Date("invalid"));
+  } catch (err) {
+    expect((err as z.ZodError).issues[0].message).toEqual("Ugyldig dato");
+  }
+});
+
+test("array parser error messages", () => {
+  const schema = z.string().array();
+
+  expect(getErrorMessage(schema.safeParse(""))).toEqual(
+    "Forventet Array, mottok String"
+  );
+  expect(getErrorMessage(schema.min(5).safeParse([""]))).toEqual(
+    "Array må inneholde minst 5 element(er)"
+  );
+  expect(getErrorMessage(schema.max(2).safeParse(["", "", ""]))).toEqual(
+    "Array må inneholde maksimalt 2 element(er)"
+  );
+  expect(getErrorMessage(schema.nonempty().safeParse([]))).toEqual(
+    "Array må inneholde minst 1 element(er)"
+  );
+  expect(getErrorMessage(schema.length(2).safeParse([]))).toEqual(
+    "Array må inneholde nøyaktig 2 element(er)"
+  );
+});
+
+test("function parser error messages", () => {
+  const functionParse = z
+    .function(z.tuple([z.string()]), z.number())
+    .parse((a: any) => a);
+  expect(getErrorMessageFromZodError(() => functionParse(""))).toEqual(
+    "Ugyldig returtype"
+  );
+  expect(getErrorMessageFromZodError(() => functionParse(1 as any))).toEqual(
+    "Ugyldige funksjonsargumenter"
+  );
+});
+
+test("other parser error messages", () => {
+  expect(
+    getErrorMessage(
+      z
+        .intersection(
+          z.number(),
+          z.number().transform((x) => x + 1)
+        )
+        .safeParse(1234)
+    )
+  ).toEqual("Kryssresultater kunne ikke slås sammen");
+  expect(getErrorMessage(z.literal(12).safeParse(""))).toEqual(
+    "Ugyldig bokstavlig verdi, forventet 12"
+  );
+  expect(getErrorMessage(z.enum(["A", "B", "C"]).safeParse("D"))).toEqual(
+    "Ugyldig enum-verdi. Forventet 'A' | 'B' | 'C', mottatt 'D'"
+  );
+  expect(
+    getErrorMessage(
+      z
+        .object({ dog: z.string() })
+        .strict()
+        .safeParse({ dog: "", cat: "", rat: "" })
+    )
+  ).toEqual("Ukjent nøkkel i objektet: 'cat', 'rat'");
+  expect(
+    getErrorMessage(
+      z
+        .discriminatedUnion("type", [
+          z.object({ type: z.literal("a"), a: z.string() }),
+          z.object({ type: z.literal("b"), b: z.string() }),
+        ])
+        .safeParse({ type: "c", c: "abc" })
+    )
+  ).toEqual("Ugyldig diskriminatorverdi, forventet 'a' | 'b'");
+  expect(
+    getErrorMessage(z.union([z.string(), z.number()]).safeParse([true]))
+  ).toEqual("Ugyldig inndata");
+  expect(
+    getErrorMessage(
+      z
+        .string()
+        .refine(() => {
+          return false;
+        })
+        .safeParse("")
+    )
+  ).toEqual("Ugyldig inndata");
+});


### PR DESCRIPTION
Added Norwegian language. Norway has two written languages, bokmål and nynorsk. Bokmål is the standard with code "nb".