### PR TITLE
fix: Fix missing Spanish translations

### DIFF
--- a/packages/core/locales/es/zod.json
+++ b/packages/core/locales/es/zod.json
@@ -1,34 +1,34 @@
 {
   "errors": {
-    "invalid_type": "Esperado {{expected}}, recibido {{received}}",
+    "invalid_type": "Se esperaba {{expected}}, se recibió {{received}}",
     "invalid_type_received_undefined": "Requerido",
-    "invalid_literal": "Valor literal inválido, era esperado {{expected}}",
+    "invalid_literal": "Valor literal inválido, se esperaba {{expected}}",
     "unrecognized_keys": "Llave(s) no reconocida(s) en el objeto: {{- keys}}",
     "invalid_union": "Entrada inválida",
-    "invalid_union_discriminator": "Valor discriminador inválido. Era esperado {{- options}}",
-    "invalid_enum_value": "Valor de enum inválido. Era esperado {{- options}}, fue recibido '{{received}}'",
-    "invalid_arguments": "Argumentos de función inválido",
+    "invalid_union_discriminator": "Valor discriminador inválido. Se esperaba {{- options}}",
+    "invalid_enum_value": "Valor inválido. Se esperaba {{- options}}, se recibió '{{received}}'",
+    "invalid_arguments": "Argumentos de función inválidos",
     "invalid_return_type": "Tipo de retorno de función inválido",
     "invalid_date": "Fecha inválida",
     "custom": "Entrada inválida",
     "invalid_intersection_types": "Valores de intersección no pudieron ser mezclados",
-    "not_multiple_of": "Número debe ser multiplo de {{multipleOf}}",
+    "not_multiple_of": "Número debe ser múltiplo de {{multipleOf}}",
     "not_finite": "Número no puede ser infinito",
     "invalid_string": {
       "email": "{{validation}} inválido",
-      "url": "{{validation}} inválida",
+      "url": "{{validation}} inválido",
       "uuid": "{{validation}} inválido",
       "cuid": "{{validation}} inválido",
       "regex": "Inválido",
-      "datetime": "{{validation}} inválido",
+      "datetime": "{{validation}} inválida",
       "startsWith": "Entrada inválida: debe comenzar con \"{{startsWith}}\"",
       "endsWith": "Entrada inválida: debe finalizar con \"{{endsWith}}\""
     },
     "too_small": {
       "array": {
-        "exact": "El array debe contener exactamente {{minimum}} elemento(s)",
-        "inclusive": "El array debe contener al menos {{minimum}} elemento(s)",
-        "not_inclusive": "El array debe contener más de {{minimum}} elemento(s)"
+        "exact": "La lista debe contener exactamente {{minimum}} elemento(s)",
+        "inclusive": "La lista debe contener al menos {{minimum}} elemento(s)",
+        "not_inclusive": "La lista debe contener más de {{minimum}} elemento(s)"
       },
       "string": {
         "exact": "El texto debe contener exactamente {{minimum}} carácter(es)",
@@ -38,7 +38,7 @@
       "number": {
         "exact": "El número debe ser exactamente {{minimum}}",
         "inclusive": "El número debe ser mayor o igual a {{minimum}}",
-        "not_inclusive": "El número debe ser mayor a {{minimum}}"
+        "not_inclusive": "El número debe ser mayor que {{minimum}}"
       },
       "set": {
         "exact": "Entrada inválida",
@@ -47,25 +47,25 @@
       },
       "date": {
         "exact": "La fecha debe ser exactamente {{- minimum, datetime}}",
-        "inclusive": "La fecha debe ser mayor o igual a {{- minimum, datetime}}",
-        "not_inclusive": "La fecha debe ser mayor a {{- minimum, datetime}}"
+        "inclusive": "La fecha debe ser mayor o igual al {{- minimum, datetime}}",
+        "not_inclusive": "La fecha debe ser mayor que el {{- minimum, datetime}}"
       }
     },
     "too_big": {
       "array": {
-        "exact": "El array debe contener exactamente {{maximum}} elemento(s)",
-        "inclusive": "El array debe contener como máximo {{maximum}} elemento(s)",
-        "not_inclusive": "El array debe contener menos que {{maximum}} elemento(s)"
+        "exact": "La lista debe contener exactamente {{maximum}} elemento(s)",
+        "inclusive": "La lista debe contener como máximo {{maximum}} elemento(s)",
+        "not_inclusive": "La lista debe contener menos que {{maximum}} elemento(s)"
       },
       "string": {
         "exact": "El texto debe contener exactamente {{maximum}} carácter(es)",
         "inclusive": "El texto debe contener como máximo {{maximum}} carácter(es)",
-        "not_inclusive": "El texto debe contener menos que {{maximum}} carácter(es)"
+        "not_inclusive": "El texto debe contener menos de {{maximum}} carácter(es)"
       },
       "number": {
         "exact": "El número debe ser exactamente {{maximum}}",
         "inclusive": "El número debe ser menor o igual a {{maximum}}",
-        "not_inclusive": "El número debe ser menor a {{maximum}}"
+        "not_inclusive": "El número debe ser menor que {{maximum}}"
       },
       "set": {
         "exact": "Entrada inválida",
@@ -74,39 +74,39 @@
       },
       "date": {
         "exact": "La fecha debe ser exactamente {{- maximum, datetime}}",
-        "inclusive": "La fecha debe ser menor o igual a {{- maximum, datetime}}",
-        "not_inclusive": "La fecha debe ser menor a {{- maximum, datetime}}"
+        "inclusive": "La fecha debe ser menor o igual al {{- maximum, datetime}}",
+        "not_inclusive": "La fecha debe ser menor que el {{- maximum, datetime}}"
       }
     }
   },
   "validations": {
     "email": "correo",
-    "url": "url",
+    "url": "enlace",
     "uuid": "uuid",
     "cuid": "cuid",
     "regex": "expresión regular",
-    "datetime": "datetime"
+    "datetime": "fecha"
   },
   "types": {
-    "function": "function",
-    "number": "number",
-    "string": "string",
-    "nan": "nan",
-    "integer": "integer",
-    "float": "float",
-    "boolean": "boolean",
-    "date": "date",
-    "bigint": "bigint",
-    "undefined": "undefined",
-    "symbol": "symbol",
-    "null": "null",
-    "array": "array",
-    "object": "object",
-    "unknown": "unknown",
-    "promise": "promise",
+    "function": "función",
+    "number": "número",
+    "string": "texto",
+    "nan": "valor no númerico",
+    "integer": "entero",
+    "float": "decimal",
+    "boolean": "booleano",
+    "date": "fecha",
+    "bigint": "entero grande",
+    "undefined": "indefinido",
+    "symbol": "símbolo",
+    "null": "nulo",
+    "array": "lista",
+    "object": "objeto",
+    "unknown": "desconocido",
+    "promise": "promesa",
     "void": "void",
-    "never": "never",
-    "map": "map",
-    "set": "set"
+    "never": "nunca",
+    "map": "mapa",
+    "set": "conjunto"
   }
 }

--- a/packages/core/tests/integrations/es.test.ts
+++ b/packages/core/tests/integrations/es.test.ts
@@ -13,21 +13,23 @@ test("string parser error messages", () => {
 
   expect(getErrorMessage(schema.safeParse(undefined))).toEqual("Requerido");
   expect(getErrorMessage(schema.safeParse(1))).toEqual(
-    "Esperado string, recibido number"
+    "Se esperaba texto, se recibió número"
   );
   expect(getErrorMessage(schema.safeParse(true))).toEqual(
-    "Esperado string, recibido boolean"
+    "Se esperaba texto, se recibió booleano"
   );
   expect(getErrorMessage(schema.safeParse(Date))).toEqual(
-    "Esperado string, recibido function"
+    "Se esperaba texto, se recibió función"
   );
   expect(getErrorMessage(schema.safeParse(new Date()))).toEqual(
-    "Esperado string, recibido date"
+    "Se esperaba texto, se recibió fecha"
   );
   expect(getErrorMessage(schema.email().safeParse(""))).toEqual(
     "correo inválido"
   );
-  expect(getErrorMessage(schema.url().safeParse(""))).toEqual("url inválida");
+  expect(getErrorMessage(schema.url().safeParse(""))).toEqual(
+    "enlace inválido"
+  );
   expect(getErrorMessage(schema.regex(/aaa/).safeParse(""))).toEqual(
     "Inválido"
   );
@@ -48,7 +50,7 @@ test("string parser error messages", () => {
   );
   expect(
     getErrorMessage(schema.datetime().safeParse("2020-01-01T00:00:00+02:00"))
-  ).toEqual("datetime inválido");
+  ).toEqual("fecha inválida");
 });
 
 test("number parser error messages", () => {
@@ -56,31 +58,31 @@ test("number parser error messages", () => {
 
   expect(getErrorMessage(schema.safeParse(undefined))).toEqual("Requerido");
   expect(getErrorMessage(schema.safeParse(""))).toEqual(
-    "Esperado number, recibido string"
+    "Se esperaba número, se recibió texto"
   );
   expect(getErrorMessage(schema.safeParse(null))).toEqual(
-    "Esperado number, recibido null"
+    "Se esperaba número, se recibió nulo"
   );
   expect(getErrorMessage(schema.safeParse(NaN))).toEqual(
-    "Esperado number, recibido nan"
+    "Se esperaba número, se recibió valor no númerico"
   );
   expect(getErrorMessage(schema.int().safeParse(0.1))).toEqual(
-    "Esperado integer, recibido float"
+    "Se esperaba entero, se recibió decimal"
   );
   expect(getErrorMessage(schema.multipleOf(5).safeParse(2))).toEqual(
-    "Número debe ser multiplo de 5"
+    "Número debe ser múltiplo de 5"
   );
   expect(getErrorMessage(schema.step(0.1).safeParse(0.0001))).toEqual(
-    "Número debe ser multiplo de 0.1"
+    "Número debe ser múltiplo de 0.1"
   );
   expect(getErrorMessage(schema.lt(5).safeParse(10))).toEqual(
-    "El número debe ser menor a 5"
+    "El número debe ser menor que 5"
   );
   expect(getErrorMessage(schema.lte(5).safeParse(10))).toEqual(
     "El número debe ser menor o igual a 5"
   );
   expect(getErrorMessage(schema.gt(5).safeParse(1))).toEqual(
-    "El número debe ser mayor a 5"
+    "El número debe ser mayor que 5"
   );
   expect(getErrorMessage(schema.gte(5).safeParse(1))).toEqual(
     "El número debe ser mayor o igual a 5"
@@ -92,10 +94,10 @@ test("number parser error messages", () => {
     "El número debe ser menor o igual a 0"
   );
   expect(getErrorMessage(schema.negative().safeParse(1))).toEqual(
-    "El número debe ser menor a 0"
+    "El número debe ser menor que 0"
   );
   expect(getErrorMessage(schema.positive().safeParse(0))).toEqual(
-    "El número debe ser mayor a 0"
+    "El número debe ser mayor que 0"
   );
   expect(getErrorMessage(schema.finite().safeParse(Infinity))).toEqual(
     "Número no puede ser infinito"
@@ -107,17 +109,17 @@ test("date parser error messages", async () => {
   const schema = z.date();
 
   expect(getErrorMessage(schema.safeParse("2022-12-01"))).toEqual(
-    "Esperado date, recibido string"
+    "Se esperaba fecha, se recibió texto"
   );
   expect(
     getErrorMessage(schema.min(testDate).safeParse(new Date("2022-07-29")))
   ).toEqual(
-    `La fecha debe ser mayor o igual a ${testDate.toLocaleDateString(LOCALE)}`
+    `La fecha debe ser mayor o igual al ${testDate.toLocaleDateString(LOCALE)}`
   );
   expect(
     getErrorMessage(schema.max(testDate).safeParse(new Date("2022-08-02")))
   ).toEqual(
-    `La fecha debe ser menor o igual a ${testDate.toLocaleDateString(LOCALE)}`
+    `La fecha debe ser menor o igual al ${testDate.toLocaleDateString(LOCALE)}`
   );
   try {
     await schema.parseAsync(new Date("invalid"));
@@ -130,19 +132,19 @@ test("array parser error messages", () => {
   const schema = z.string().array();
 
   expect(getErrorMessage(schema.safeParse(""))).toEqual(
-    "Esperado array, recibido string"
+    "Se esperaba lista, se recibió texto"
   );
   expect(getErrorMessage(schema.min(5).safeParse([""]))).toEqual(
-    "El array debe contener al menos 5 elemento(s)"
+    "La lista debe contener al menos 5 elemento(s)"
   );
   expect(getErrorMessage(schema.max(2).safeParse(["", "", ""]))).toEqual(
-    "El array debe contener como máximo 2 elemento(s)"
+    "La lista debe contener como máximo 2 elemento(s)"
   );
   expect(getErrorMessage(schema.nonempty().safeParse([]))).toEqual(
-    "El array debe contener al menos 1 elemento(s)"
+    "La lista debe contener al menos 1 elemento(s)"
   );
   expect(getErrorMessage(schema.length(2).safeParse([]))).toEqual(
-    "El array debe contener exactamente 2 elemento(s)"
+    "La lista debe contener exactamente 2 elemento(s)"
   );
 });
 
@@ -154,7 +156,7 @@ test("function parser error messages", () => {
     "Tipo de retorno de función inválido"
   );
   expect(getErrorMessageFromZodError(() => functionParse(1 as any))).toEqual(
-    "Argumentos de función inválido"
+    "Argumentos de función inválidos"
   );
 });
 
@@ -170,10 +172,10 @@ test("other parser error messages", () => {
     )
   ).toEqual("Valores de intersección no pudieron ser mezclados");
   expect(getErrorMessage(z.literal(12).safeParse(""))).toEqual(
-    "Valor literal inválido, era esperado 12"
+    "Valor literal inválido, se esperaba 12"
   );
   expect(getErrorMessage(z.enum(["A", "B", "C"]).safeParse("D"))).toEqual(
-    "Valor de enum inválido. Era esperado 'A' | 'B' | 'C', fue recibido 'D'"
+    "Valor inválido. Se esperaba 'A' | 'B' | 'C', se recibió 'D'"
   );
   expect(
     getErrorMessage(
@@ -192,7 +194,7 @@ test("other parser error messages", () => {
         ])
         .safeParse({ type: "c", c: "abc" })
     )
-  ).toEqual("Valor discriminador inválido. Era esperado 'a' | 'b'");
+  ).toEqual("Valor discriminador inválido. Se esperaba 'a' | 'b'");
   expect(
     getErrorMessage(z.union([z.string(), z.number()]).safeParse([true]))
   ).toEqual("Entrada inválida");


### PR DESCRIPTION
In this PR I replaced some of the missing Spanish translations from the original file and also updated the tests for it.

For example, the `types` where not translated, several uses of the `date` word where wrongly translated and a few minor other grammar corrections.