### PR TITLE
feat(localizations): Add uk-UA localization

### DIFF
--- a/examples/with-next-i18next/next-i18next.config.js
+++ b/examples/with-next-i18next/next-i18next.config.js
@@ -26,6 +26,7 @@ module.exports = {
       "lt",
       "ru",
       "ro",
+      "uk-UA",
     ],
   },
   localePath: path.resolve("./public/locales"),

--- a/examples/with-next-i18next/pages/index.tsx
+++ b/examples/with-next-i18next/pages/index.tsx
@@ -91,6 +91,7 @@ export default function HookForm() {
             <option value="pt">Português</option>
             <option value="pl">polski</option>
             <option value="ru">Русский</option>
+            <option value="uk-UA">Українська</option>
             <option value="ro">Română</option>
             <option value="tr">Türkçe</option>
             <option value="zh-CN">简体中文</option>

--- a/examples/with-next-i18next/public/locales/uk-UA/common.json
+++ b/examples/with-next-i18next/public/locales/uk-UA/common.json
@@ -1,0 +1,7 @@
+{
+  "username": "Ім'я користувача",
+  "username_placeholder": "John Doe",
+  "email": "Email",
+  "favoriteNumber": "Улюблений номер",
+  "submit": "Відправити"
+}

--- a/examples/with-next-i18next/public/locales/uk-UA/zod.json
+++ b/examples/with-next-i18next/public/locales/uk-UA/zod.json
@@ -1,0 +1,112 @@
+{
+  "errors": {
+    "invalid_type": "Очікувався тип {{expected}}, отримано {{received}}",
+    "invalid_type_received_undefined": "Обов'язковe поле",
+    "invalid_literal": "Невірне літеральне значення, очікувалось {{expected}}",
+    "unrecognized_keys": "Нерозпізнані ключі в об'єкті: {{- keys}}",
+    "invalid_union": "Невірне введення",
+    "invalid_union_discriminator": "Неправильне значення дискримінатора. Очікувалось {{- options}}",
+    "invalid_enum_value": "Невірне значення enum. Очікувалося {{- options}}, отримано '{{received}}'",
+    "invalid_arguments": "Невірні аргументи функції",
+    "invalid_return_type": "Невірний тип значення, що повертається функцією",
+    "invalid_date": "Невірний формат дати",
+    "custom": "Невірне введення",
+    "invalid_intersection_types": "Результати перетину не вдалося об'єднати",
+    "not_multiple_of": "Число повинно бути кратним {{multipleOf}}",
+    "not_finite": "Число повинно бути скінченним",
+    "invalid_string": {
+      "email": "Невірний {{validation}}",
+      "url": "Невірний {{validation}}",
+      "uuid": "Невірне введення {{validation}}",
+      "cuid": "Невірне введення {{validation}}",
+      "regex": "Невдала валідація",
+      "datetime": "Невірний формат {{validation}}",
+      "startsWith": "Невірне введення: повинно починатись з \"{{startsWith}}\"",
+      "endsWith": "Невірне введення: повинно закінчуватись на \"{{endsWith}}\""
+    },
+    "too_small": {
+      "array": {
+        "exact": "Масив повинен містити рівно {{minimum}} елемента(-ів)",
+        "inclusive": "Масив повинен містити щонайменше {{minimum}} елемента(-ів)",
+        "not_inclusive": "Масив повинен містити більше {{minimum}} елемента(-ів)"
+      },
+      "string": {
+        "exact": "Рядок повинен містити рівно {{minimum}} символа(-ів)",
+        "inclusive": "Рядок повинен містити щонайменше {{minimum}} символа(-ів)",
+        "not_inclusive": "Рядок повинен містити більше {{minimum}} символа(-ів)"
+      },
+      "number": {
+        "exact": "Число повинно бути рівне {{minimum}}",
+        "inclusive": "Число повинно бути більше або дорівнювати {{minimum}}",
+        "not_inclusive": "Число повинно бути більше {{minimum}}"
+      },
+      "set": {
+        "exact": "Невірний ввід",
+        "inclusive": "Невірний ввід",
+        "not_inclusive": "Невірний ввід"
+      },
+      "date": {
+        "exact": "Дата повинно бути точно {{- minimum, datetime}}",
+        "inclusive": "Дата повинно бути більшою або рівною {{- minimum, datetime}}",
+        "not_inclusive": "Дата повинно бути більшою ніж {{-minimum, datetime}}"
+      }
+    },
+    "too_big": {
+      "array": {
+        "exact": "Масив повинен містити рівно {{maximum}} елемента(-ів)",
+        "inclusive": "Масив повинен містити не більше {{maximum}} елемента(-ів)",
+        "not_inclusive": "Масив повинен містити менше {{maximum}} елемента(-ів)"
+      },
+      "string": {
+        "exact": "Рядок повинен містити рівно {{maximum}} символа(-ів)",
+        "inclusive": "Рядок повинен містити не більше {{maximum}} символа(-ів)",
+        "not_inclusive": "Рядок повинен містити менше {{maximum}} символа(-ів)"
+      },
+      "number": {
+        "exact": "Число повинно бути рівно {{maximum}}",
+        "inclusive": "Число повинно бути менше або дорівнювати {{maximum}}",
+        "not_inclusive": "Число повинно бути менше {{maximum}}"
+      },
+      "set": {
+        "exact": "Неправильний ввід",
+        "inclusive": "Невірне введення",
+        "not_inclusive": "Невірний ввід"
+      },
+      "date": {
+        "exact": "Дата повинна бути точно {{- maximum, datetime}}",
+        "inclusive": "Дата повинна бути меншою або дорівнювати {{- maximum, datetime}}",
+        "not_inclusive": "Дата повинно бути меншою ніж {{- maximum, datetime}}"
+      }
+    }
+  },
+  "validations": {
+    "email": "email",
+    "url": "url",
+    "uuid": "uuid",
+    "cuid": "cuid",
+    "regex": "regex",
+    "datetime": "datetime"
+  },
+  "types": {
+    "function": "function",
+    "number": "number",
+    "string": "string",
+    "nan": "NaN",
+    "integer": "integer",
+    "float": "float",
+    "boolean": "boolean",
+    "date": "date",
+    "bigint": "bigint",
+    "undefined": "undefined",
+    "symbol": "symbol",
+    "null": "null",
+    "array": "array",
+    "object": "object",
+    "unknown": "unknown",
+    "promise": "promise",
+    "void": "void",
+    "never": "never",
+    "map": "map",
+    "set": "set"
+  }
+}

--- a/packages/core/locales/uk-UA/zod.json
+++ b/packages/core/locales/uk-UA/zod.json
@@ -1,0 +1,112 @@
+{
+  "errors": {
+    "invalid_type": "Очікувався тип {{expected}}, отримано {{received}}",
+    "invalid_type_received_undefined": "Обов'язковe поле",
+    "invalid_literal": "Невірне літеральне значення, очікувалось {{expected}}",
+    "unrecognized_keys": "Нерозпізнані ключі в об'єкті: {{- keys}}",
+    "invalid_union": "Невірне введення",
+    "invalid_union_discriminator": "Неправильне значення дискримінатора. Очікувалось {{- options}}",
+    "invalid_enum_value": "Невірне значення enum. Очікувалося {{- options}}, отримано '{{received}}'",
+    "invalid_arguments": "Невірні аргументи функції",
+    "invalid_return_type": "Невірний тип значення, що повертається функцією",
+    "invalid_date": "Невірний формат дати",
+    "custom": "Невірне введення",
+    "invalid_intersection_types": "Результати перетину не вдалося об'єднати",
+    "not_multiple_of": "Число повинно бути кратним {{multipleOf}}",
+    "not_finite": "Число повинно бути скінченним",
+    "invalid_string": {
+      "email": "Невірний {{validation}}",
+      "url": "Невірний {{validation}}",
+      "uuid": "Невірне введення {{validation}}",
+      "cuid": "Невірне введення {{validation}}",
+      "regex": "Невдала валідація",
+      "datetime": "Невірний формат {{validation}}",
+      "startsWith": "Невірне введення: повинно починатись з \"{{startsWith}}\"",
+      "endsWith": "Невірне введення: повинно закінчуватись на \"{{endsWith}}\""
+    },
+    "too_small": {
+      "array": {
+        "exact": "Масив повинен містити рівно {{minimum}} елемента(-ів)",
+        "inclusive": "Масив повинен містити щонайменше {{minimum}} елемента(-ів)",
+        "not_inclusive": "Масив повинен містити більше {{minimum}} елемента(-ів)"
+      },
+      "string": {
+        "exact": "Рядок повинен містити рівно {{minimum}} символа(-ів)",
+        "inclusive": "Рядок повинен містити щонайменше {{minimum}} символа(-ів)",
+        "not_inclusive": "Рядок повинен містити більше {{minimum}} символа(-ів)"
+      },
+      "number": {
+        "exact": "Число повинно бути рівне {{minimum}}",
+        "inclusive": "Число повинно бути більше або дорівнювати {{minimum}}",
+        "not_inclusive": "Число повинно бути більше {{minimum}}"
+      },
+      "set": {
+        "exact": "Невірний ввід",
+        "inclusive": "Невірний ввід",
+        "not_inclusive": "Невірний ввід"
+      },
+      "date": {
+        "exact": "Дата повинно бути точно {{- minimum, datetime}}",
+        "inclusive": "Дата повинно бути більшою або рівною {{- minimum, datetime}}",
+        "not_inclusive": "Дата повинно бути більшою ніж {{-minimum, datetime}}"
+      }
+    },
+    "too_big": {
+      "array": {
+        "exact": "Масив повинен містити рівно {{maximum}} елемента(-ів)",
+        "inclusive": "Масив повинен містити не більше {{maximum}} елемента(-ів)",
+        "not_inclusive": "Масив повинен містити менше {{maximum}} елемента(-ів)"
+      },
+      "string": {
+        "exact": "Рядок повинен містити рівно {{maximum}} символа(-ів)",
+        "inclusive": "Рядок повинен містити не більше {{maximum}} символа(-ів)",
+        "not_inclusive": "Рядок повинен містити менше {{maximum}} символа(-ів)"
+      },
+      "number": {
+        "exact": "Число повинно бути рівно {{maximum}}",
+        "inclusive": "Число повинно бути менше або дорівнювати {{maximum}}",
+        "not_inclusive": "Число повинно бути менше {{maximum}}"
+      },
+      "set": {
+        "exact": "Неправильний ввід",
+        "inclusive": "Невірне введення",
+        "not_inclusive": "Невірний ввід"
+      },
+      "date": {
+        "exact": "Дата повинна бути точно {{- maximum, datetime}}",
+        "inclusive": "Дата повинна бути меншою або дорівнювати {{- maximum, datetime}}",
+        "not_inclusive": "Дата повинно бути меншою ніж {{- maximum, datetime}}"
+      }
+    }
+  },
+  "validations": {
+    "email": "email",
+    "url": "url",
+    "uuid": "uuid",
+    "cuid": "cuid",
+    "regex": "regex",
+    "datetime": "datetime"
+  },
+  "types": {
+    "function": "function",
+    "number": "number",
+    "string": "string",
+    "nan": "NaN",
+    "integer": "integer",
+    "float": "float",
+    "boolean": "boolean",
+    "date": "date",
+    "bigint": "bigint",
+    "undefined": "undefined",
+    "symbol": "symbol",
+    "null": "null",
+    "array": "array",
+    "object": "object",
+    "unknown": "unknown",
+    "promise": "promise",
+    "void": "void",
+    "never": "never",
+    "map": "map",
+    "set": "set"
+  }
+}

--- a/packages/core/tests/integrations/uk-UA.test.ts
+++ b/packages/core/tests/integrations/uk-UA.test.ts
@@ -1,0 +1,219 @@
+import { test, expect, beforeAll } from "vitest";
+import { z } from "zod";
+import { init, getErrorMessage, getErrorMessageFromZodError } from "./helpers";
+
+const LOCALE = "uk-UA";
+
+beforeAll(async () => {
+  await init(LOCALE);
+});
+
+test("string parser error messages", () => {
+  const schema = z.string();
+
+  expect(getErrorMessage(schema.safeParse(undefined))).toEqual(
+    "Обов'язковe поле"
+  );
+  expect(getErrorMessage(schema.safeParse(1))).toEqual(
+    "Очікувався тип string, отримано number"
+  );
+  expect(getErrorMessage(schema.safeParse(true))).toEqual(
+    "Очікувався тип string, отримано boolean"
+  );
+  expect(getErrorMessage(schema.safeParse(Date))).toEqual(
+    "Очікувався тип string, отримано function"
+  );
+  expect(getErrorMessage(schema.safeParse(new Date()))).toEqual(
+    "Очікувався тип string, отримано date"
+  );
+  expect(getErrorMessage(schema.email().safeParse(""))).toEqual(
+    "Невірний email"
+  );
+  expect(getErrorMessage(schema.url().safeParse(""))).toEqual("Невірний url");
+  expect(getErrorMessage(schema.regex(/aaa/).safeParse(""))).toEqual(
+    "Невдала валідація"
+  );
+  expect(getErrorMessage(schema.startsWith("foo").safeParse(""))).toEqual(
+    'Невірне введення: повинно починатись з "foo"'
+  );
+  expect(getErrorMessage(schema.endsWith("bar").safeParse(""))).toEqual(
+    'Невірне введення: повинно закінчуватись на "bar"'
+  );
+  expect(getErrorMessage(schema.min(5).safeParse("a"))).toEqual(
+    "Рядок повинен містити щонайменше 5 символа(-ів)"
+  );
+  expect(getErrorMessage(schema.max(5).safeParse("abcdef"))).toEqual(
+    "Рядок повинен містити не більше 5 символа(-ів)"
+  );
+  expect(getErrorMessage(schema.length(5).safeParse("abcdef"))).toEqual(
+    "Рядок повинен містити рівно 5 символа(-ів)"
+  );
+  expect(
+    getErrorMessage(schema.datetime().safeParse("2020-01-01T00:00:00+02:00"))
+  ).toEqual("Невірний формат datetime");
+});
+
+test("number parser error messages", () => {
+  const schema = z.number();
+
+  expect(getErrorMessage(schema.safeParse(undefined))).toEqual(
+    "Обов'язковe поле"
+  );
+  expect(getErrorMessage(schema.safeParse(""))).toEqual(
+    "Очікувався тип number, отримано string"
+  );
+  expect(getErrorMessage(schema.safeParse(null))).toEqual(
+    "Очікувався тип number, отримано null"
+  );
+  expect(getErrorMessage(schema.safeParse(NaN))).toEqual(
+    "Очікувався тип number, отримано NaN"
+  );
+  expect(getErrorMessage(schema.int().safeParse(0.1))).toEqual(
+    "Очікувався тип integer, отримано float"
+  );
+  expect(getErrorMessage(schema.multipleOf(5).safeParse(2))).toEqual(
+    "Число повинно бути кратним 5"
+  );
+  expect(getErrorMessage(schema.step(0.1).safeParse(0.0001))).toEqual(
+    "Число повинно бути кратним 0.1"
+  );
+  expect(getErrorMessage(schema.lt(5).safeParse(10))).toEqual(
+    "Число повинно бути менше 5"
+  );
+  expect(getErrorMessage(schema.lte(5).safeParse(10))).toEqual(
+    "Число повинно бути менше або дорівнювати 5"
+  );
+  expect(getErrorMessage(schema.gt(5).safeParse(1))).toEqual(
+    "Число повинно бути більше 5"
+  );
+  expect(getErrorMessage(schema.gte(5).safeParse(1))).toEqual(
+    "Число повинно бути більше або дорівнювати 5"
+  );
+  expect(getErrorMessage(schema.nonnegative().safeParse(-1))).toEqual(
+    "Число повинно бути більше або дорівнювати 0"
+  );
+  expect(getErrorMessage(schema.nonpositive().safeParse(1))).toEqual(
+    "Число повинно бути менше або дорівнювати 0"
+  );
+  expect(getErrorMessage(schema.negative().safeParse(1))).toEqual(
+    "Число повинно бути менше 0"
+  );
+  expect(getErrorMessage(schema.positive().safeParse(0))).toEqual(
+    "Число повинно бути більше 0"
+  );
+  expect(getErrorMessage(schema.finite().safeParse(Infinity))).toEqual(
+    "Число повинно бути скінченним"
+  );
+});
+
+test("date parser error messages", async () => {
+  const testDate = new Date("2022-08-01");
+  const schema = z.date();
+
+  expect(getErrorMessage(schema.safeParse("2022-12-01"))).toEqual(
+    "Очікувався тип date, отримано string"
+  );
+  expect(
+    getErrorMessage(schema.min(testDate).safeParse(new Date("2022-07-29")))
+  ).toEqual(
+    `Дата повинно бути більшою або рівною ${testDate.toLocaleDateString(
+      LOCALE
+    )}`
+  );
+  expect(
+    getErrorMessage(schema.max(testDate).safeParse(new Date("2022-08-02")))
+  ).toEqual(
+    `Дата повинна бути меншою або дорівнювати ${testDate.toLocaleDateString(
+      LOCALE
+    )}`
+  );
+  try {
+    await schema.parseAsync(new Date("invalid"));
+  } catch (err) {
+    expect((err as z.ZodError).issues[0].message).toEqual(
+      "Невірний формат дати"
+    );
+  }
+});
+
+test("array parser error messages", () => {
+  const schema = z.string().array();
+
+  expect(getErrorMessage(schema.safeParse(""))).toEqual(
+    "Очікувався тип array, отримано string"
+  );
+  expect(getErrorMessage(schema.min(5).safeParse([""]))).toEqual(
+    "Масив повинен містити щонайменше 5 елемента(-ів)"
+  );
+  expect(getErrorMessage(schema.max(2).safeParse(["", "", ""]))).toEqual(
+    "Масив повинен містити не більше 2 елемента(-ів)"
+  );
+  expect(getErrorMessage(schema.nonempty().safeParse([]))).toEqual(
+    "Масив повинен містити щонайменше 1 елемента(-ів)"
+  );
+  expect(getErrorMessage(schema.length(2).safeParse([]))).toEqual(
+    "Масив повинен містити рівно 2 елемента(-ів)"
+  );
+});
+
+test("function parser error messages", () => {
+  const functionParse = z
+    .function(z.tuple([z.string()]), z.number())
+    .parse((a: any) => a);
+  expect(getErrorMessageFromZodError(() => functionParse(""))).toEqual(
+    "Невірний тип значення, що повертається функцією"
+  );
+  expect(getErrorMessageFromZodError(() => functionParse(1 as any))).toEqual(
+    "Невірні аргументи функції"
+  );
+});
+
+test("other parser error messages", () => {
+  expect(
+    getErrorMessage(
+      z
+        .intersection(
+          z.number(),
+          z.number().transform((x) => x + 1)
+        )
+        .safeParse(1234)
+    )
+  ).toEqual("Результати перетину не вдалося об'єднати");
+  expect(getErrorMessage(z.literal(12).safeParse(""))).toEqual(
+    "Невірне літеральне значення, очікувалось 12"
+  );
+  expect(getErrorMessage(z.enum(["A", "B", "C"]).safeParse("D"))).toEqual(
+    "Невірне значення enum. Очікувалося 'A' | 'B' | 'C', отримано 'D'"
+  );
+  expect(
+    getErrorMessage(
+      z
+        .object({ dog: z.string() })
+        .strict()
+        .safeParse({ dog: "", cat: "", rat: "" })
+    )
+  ).toEqual("Нерозпізнані ключі в об'єкті: 'cat', 'rat'");
+  expect(
+    getErrorMessage(
+      z
+        .discriminatedUnion("type", [
+          z.object({ type: z.literal("a"), a: z.string() }),
+          z.object({ type: z.literal("b"), b: z.string() }),
+        ])
+        .safeParse({ type: "c", c: "abc" })
+    )
+  ).toEqual("Неправильне значення дискримінатора. Очікувалось 'a' | 'b'");
+  expect(
+    getErrorMessage(z.union([z.string(), z.number()]).safeParse([true]))
+  ).toEqual("Невірне введення");
+  expect(
+    getErrorMessage(
+      z
+        .string()
+        .refine(() => {
+          return false;
+        })
+        .safeParse("")
+    )
+  ).toEqual("Невірне введення");
+});


### PR DESCRIPTION
feat: add locale uk-UA (ukrainian language) to locales 
- [x] add uk-UA zod.json to packages/core/locales/uk-UA
- [x] add uk-UA test to tests/integrations
- [x] add uk-UA zod.json and zod.json to examples/with-next-i18next/public/locales/uk-UA
- [x] update next-i18next.config.js add "uk-UA" to locales (in examples/with-next-i18next)
- [x] update examples/with-next-i18next/pages/index.tsx, add option  <option value="uk-UA">Українська</option>

<img src="https://res.cloudinary.com/djlxkl2xj/image/upload/v1692286856/Screenshot_3_iunp88.png">