### PR TITLE
Improve locale PT to better handle plurals

### DIFF
--- a/packages/core/locales/pt/zod.json
+++ b/packages/core/locales/pt/zod.json
@@ -5,6 +5,8 @@
     "invalid_type_received_null": "Obrigatório",
     "invalid_literal": "Valor literal inválido, era esperado {{expected}}",
     "unrecognized_keys": "Chave(s) não reconhecida(s) no objeto: {{- keys}}",
+    "unrecognized_keys_one": "Chave não reconhecida no objeto: {{- keys}}",
+    "unrecognized_keys_other": "Chaves não reconhecidas no objeto: {{- keys}}",
     "invalid_union": "Entrada inválida",
     "invalid_union_discriminator": "Valor discriminador inválido. Foi esperado {{- options}}",
     "invalid_enum_value": "Enum no formato inválido. Foi esperado {{- options}}, porém foi recebido '{{received}}'",
@@ -28,16 +30,30 @@
     "too_small": {
       "array": {
         "exact": "Lista deve conter exatamente {{minimum}} elemento(s)",
+        "exact_one": "Lista deve conter exatamente {{minimum}} elemento",
+        "exact_other": "Lista deve conter exatamente {{minimum}} elementos",
         "inclusive": "Lista deve conter no mínimo {{minimum}} elemento(s)",
-        "not_inclusive": "Lista deve conter mais de {{minimum}} elemento(s)"
+        "inclusive_one": "Lista deve conter no mínimo {{minimum}} elemento",
+        "inclusive_other": "Lista deve conter no mínimo {{minimum}} elementos",
+        "not_inclusive": "Lista deve conter mais de {{minimum}} elemento(s)",
+        "not_inclusive_one": "Lista deve conter mais de {{minimum}} elemento",
+        "not_inclusive_other": "Lista deve conter mais de {{minimum}} elementos"
       },
       "string": {
         "exact": "Texto deve conter exatamente {{minimum}} caracter(es)",
+        "exact_one": "Texto deve conter exatamente {{minimum}} caracter",
+        "exact_other": "Texto deve conter exatamente {{minimum}} caracteres",
         "inclusive": "Texto deve conter pelo menos {{minimum}} caracter(es)",
-        "not_inclusive": "Texto deve conter mais de {{minimum}} caracter(es)"
+        "inclusive_one": "Texto deve conter pelo menos {{minimum}} caracter",
+        "inclusive_other": "Texto deve conter pelo menos {{minimum}} caracteres",
+        "not_inclusive": "Texto deve conter mais de {{minimum}} caracter(es)",
+        "not_inclusive_one": "Texto deve conter mais de {{minimum}} caracter",
+        "not_inclusive_other": "Texto deve conter mais de {{minimum}} caracteres"
       },
       "number": {
         "exact": "Número deve conter exatamente {{minimum}} caracter(es)",
+        "exact_one": "Número deve conter exatamente {{minimum}} caracter",
+        "exact_other": "Número deve conter exatamente {{minimum}} caracteres",
         "inclusive": "Número deve ser maior ou igual a {{minimum}}",
         "not_inclusive": "Número deve ser maior que {{minimum}}"
       },
@@ -55,16 +71,30 @@
     "too_big": {
       "array": {
         "exact": "Lista deve conter exatamente {{maximum}} elemento(s)",
+        "exact_one": "Lista deve conter exatamente {{maximum}} elemento",
+        "exact_other": "Lista deve conter exatamente {{maximum}} elementos",
         "inclusive": "Lista deve conter no máximo {{maximum}} elemento(s)",
-        "not_inclusive": "Lista deve conter menos de {{maximum}} elemento(s)"
+        "inclusive_one": "Lista deve conter no máximo {{maximum}} elemento",
+        "inclusive_other": "Lista deve conter no máximo {{maximum}} elementos",
+        "not_inclusive": "Lista deve conter menos de {{maximum}} elemento(s)",
+        "not_inclusive_one": "Lista deve conter menos de {{maximum}} elemento",
+        "not_inclusive_other": "Lista deve conter menos de {{maximum}} elementos"
       },
       "string": {
         "exact": "Texto deve conter exatamente {{maximum}} caracter(es)",
+        "exact_one": "Texto deve conter exatamente {{maximum}} caracter",
+        "exact_other": "Texto deve conter exatamente {{maximum}} caracteres",
         "inclusive": "Texto pode conter no máximo {{maximum}} caracter(es)",
-        "not_inclusive": "Texto deve conter menos que {{maximum}} caracter(es)"
+        "inclusive_one": "Texto pode conter no máximo {{maximum}} caracter",
+        "inclusive_other": "Texto pode conter no máximo {{maximum}} caracteres",
+        "not_inclusive": "Texto deve conter menos que {{maximum}} caracter(es)",
+        "not_inclusive_one": "Texto deve conter menos que {{maximum}} caracter",
+        "not_inclusive_other": "Texto deve conter menos que {{maximum}} caracteres"
       },
       "number": {
         "exact": "Número deve conter exatamente {{maximum}} caracter(es)",
+        "exact_one": "Número deve conter exatamente {{maximum}} caracter",
+        "exact_other": "Número deve conter exatamente {{maximum}} caracteres",
         "inclusive": "Número deve ser menor ou igual a {{maximum}}",
         "not_inclusive": "Número deve ser menor que {{maximum}}"
       },

--- a/packages/core/tests/integrations/pt.test.ts
+++ b/packages/core/tests/integrations/pt.test.ts
@@ -37,14 +37,23 @@ test("string parser error messages", () => {
   expect(getErrorMessage(schema.endsWith("bar").safeParse(""))).toEqual(
     'Entrada inválida: deve terminar com "bar"'
   );
+  expect(getErrorMessage(schema.length(1).safeParse("abcdef"))).toEqual(
+    "Texto deve conter exatamente 1 caracter"
+  );
   expect(getErrorMessage(schema.length(5).safeParse("abcdef"))).toEqual(
-    "Texto deve conter exatamente 5 caracter(es)"
+    "Texto deve conter exatamente 5 caracteres"
+  );
+  expect(getErrorMessage(schema.min(1).safeParse(""))).toEqual(
+    "Texto deve conter pelo menos 1 caracter"
   );
   expect(getErrorMessage(schema.min(5).safeParse("a"))).toEqual(
-    "Texto deve conter pelo menos 5 caracter(es)"
+    "Texto deve conter pelo menos 5 caracteres"
+  );
+  expect(getErrorMessage(schema.max(1).safeParse("abcdef"))).toEqual(
+    "Texto pode conter no máximo 1 caracter"
   );
   expect(getErrorMessage(schema.max(5).safeParse("abcdef"))).toEqual(
-    "Texto pode conter no máximo 5 caracter(es)"
+    "Texto pode conter no máximo 5 caracteres"
   );
   // TODO: translation `datetime` (zod:validations.datetime and zod:errors.invalid_string.datetime)
   expect(
@@ -131,17 +140,26 @@ test("array parser error messages", () => {
   expect(getErrorMessage(schema.safeParse(""))).toEqual(
     "O dado deve ser do tipo array, porém foi enviado string"
   );
-  expect(getErrorMessage(schema.length(2).safeParse([]))).toEqual(
-    "Lista deve conter exatamente 2 elemento(s)"
+  expect(getErrorMessage(schema.length(1).safeParse([]))).toEqual(
+    "Lista deve conter exatamente 1 elemento"
   );
-  expect(getErrorMessage(schema.min(5).safeParse([""]))).toEqual(
-    "Lista deve conter no mínimo 5 elemento(s)"
+  expect(getErrorMessage(schema.length(2).safeParse([]))).toEqual(
+    "Lista deve conter exatamente 2 elementos"
+  );
+  expect(getErrorMessage(schema.min(1).safeParse([]))).toEqual(
+    "Lista deve conter no mínimo 1 elemento"
+  );
+  expect(getErrorMessage(schema.min(2).safeParse([""]))).toEqual(
+    "Lista deve conter no mínimo 2 elementos"
+  );
+  expect(getErrorMessage(schema.max(1).safeParse(["", "", ""]))).toEqual(
+    "Lista deve conter no máximo 1 elemento"
   );
   expect(getErrorMessage(schema.max(2).safeParse(["", "", ""]))).toEqual(
-    "Lista deve conter no máximo 2 elemento(s)"
+    "Lista deve conter no máximo 2 elementos"
   );
   expect(getErrorMessage(schema.nonempty().safeParse([]))).toEqual(
-    "Lista deve conter no mínimo 1 elemento(s)"
+    "Lista deve conter no mínimo 1 elemento"
   );
 });
 
@@ -176,12 +194,17 @@ test("other parser error messages", () => {
   );
   expect(
     getErrorMessage(
+      z.object({ dog: z.string() }).strict().safeParse({ dog: "", cat: "" })
+    )
+  ).toEqual("Chave não reconhecida no objeto: 'cat'");
+  expect(
+    getErrorMessage(
       z
         .object({ dog: z.string() })
         .strict()
         .safeParse({ dog: "", cat: "", rat: "" })
     )
-  ).toEqual("Chave(s) não reconhecida(s) no objeto: 'cat', 'rat'");
+  ).toEqual("Chaves não reconhecidas no objeto: 'cat', 'rat'");
   expect(
     getErrorMessage(
       z


### PR DESCRIPTION
Based on the [Plurals documentation](https://github.com/aiji42/zod-i18n#plurals), I’ve implemented proper handling for plurals for PT locale. Additionally, new tests have been added to cover these cases.