### PR TITLE
fix: more accurate translation for 'email'

### DIFF
--- a/packages/core/locales/zh-CN/zod.json
+++ b/packages/core/locales/zh-CN/zod.json
@@ -81,7 +81,7 @@
     }
   },
   "validations": {
-    "email": "邮件",
+    "email": "邮箱",
     "url": "链接",
     "uuid": "uuid",
     "cuid": "cuid",


### PR DESCRIPTION
'邮件' is more like 'mail', which means it's the content of a mail. '邮箱' is literal meaning 'mail box', which is more closer to the meaning of 'email address'.